### PR TITLE
Refactor: Simplify APK renaming in Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,7 +15,6 @@
 
 require "date"
 require 'fileutils'
-require "digest"
 
 default_platform(:android)
 
@@ -132,22 +131,12 @@ platform :android do
 
     begin
       FileUtils.rm_f(new_apk_path)
-    rescue Errno::EACCES, Errno::EPERM
+      FileUtils.mv(default_apk_path, new_apk_path)
+    rescue => e
+      raise "Failed to rename APK: #{e.message}"
     end
 
-    src_sha = Digest::SHA256.file(default_apk_path).hexdigest
-    FileUtils.cp(default_apk_path, new_apk_path, preserve: true)
-    dst_sha = Digest::SHA256.file(new_apk_path).hexdigest
-
-    raise "Checksum mismatch after copy" unless src_sha == dst_sha
-
-    begin
-      FileUtils.rm_f(default_apk_path)
-    rescue Errno::EACCES, Errno::EPERM
-      UI.important("Source still locked; keeping both #{default_apk_name} and #{new_apk_name}.")
-    end
-
-    puts "Prepared #{default_apk_name} -> #{new_apk_name}"
+    puts "Renamed #{default_apk_name} -> #{new_apk_name}"
     puts "New APK Path For Upload: #{new_apk_path}"
     new_apk_path
   end


### PR DESCRIPTION
This commit refactors the APK renaming process in `fastlane/Fastfile`.

It replaces the copy-and-delete approach with a direct `FileUtils.mv` operation for renaming the APK file. This simplifies the code and removes the need for SHA256 checksum verification and the `digest` requirement.

The error handling for the rename operation has also been updated to raise a more generic error message if the move fails.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable