### PR TITLE
Feat: Display app version in MenuScreen

### DIFF
--- a/verifierApp/src/androidMain/kotlin/eu/europa/ec/euidi/verifier/core/controller/AndroidPlatformController.kt
+++ b/verifierApp/src/androidMain/kotlin/eu/europa/ec/euidi/verifier/core/controller/AndroidPlatformController.kt
@@ -23,6 +23,7 @@ import android.net.Uri
 import android.provider.Settings
 import eu.europa.ec.euidi.verifier.BuildConfig
 import eu.europa.ec.euidi.verifier.core.controller.model.BuildType
+import eu.europa.ec.euidi.verifier.core.controller.model.FlavorType
 import java.lang.ref.WeakReference
 
 class AndroidPlatformController(
@@ -36,6 +37,12 @@ class AndroidPlatformController(
 
     override val buildType: BuildType
         get() = BuildType.from(BuildConfig.BUILD_TYPE)
+
+    override val flavorType: FlavorType
+        get() = FlavorType.from(BuildConfig.FLAVOR)
+
+    override val appVersion: String
+        get() = BuildConfig.VERSION_NAME
 
     override fun closeApp() {
         activityRef?.get()?.finish()

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/core/controller/model/FlavorType.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/core/controller/model/FlavorType.kt
@@ -14,20 +14,14 @@
  * governing permissions and limitations under the Licence.
  */
 
-package eu.europa.ec.euidi.verifier.core.controller
+package eu.europa.ec.euidi.verifier.core.controller.model
 
-import eu.europa.ec.euidi.verifier.core.controller.model.BuildType
-import eu.europa.ec.euidi.verifier.core.controller.model.FlavorType
+enum class FlavorType {
+    Dev, Public;
 
-interface PlatformController {
-
-    val buildType: BuildType
-
-    val flavorType: FlavorType
-
-    val appVersion: String
-
-    fun closeApp()
-
-    fun openAppSettings()
+    companion object {
+        fun from(type: String): FlavorType =
+            entries.find { it.name == type }
+                ?: throw IllegalArgumentException("Invalid flavor type: $type")
+    }
 }

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/config/ConfigProvider.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/config/ConfigProvider.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.euidi.verifier.domain.config
 
 import eu.europa.ec.euidi.verifier.core.controller.PlatformController
 import eu.europa.ec.euidi.verifier.core.controller.model.BuildType
+import eu.europa.ec.euidi.verifier.core.controller.model.FlavorType
 import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType
 import eu.europa.ec.euidi.verifier.domain.config.model.ClaimItem
 import eu.europa.ec.euidi.verifier.domain.config.model.DocumentMode
@@ -27,13 +28,33 @@ import eudiverifier.verifierapp.generated.resources.Res
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 
 interface ConfigProvider {
+
+    val buildType: BuildType
+
+    val flavorType: FlavorType
+
+    val appVersion: String
+
     val supportedDocuments: SupportedDocuments
+
     val logger: Logger
+
     fun getDocumentModes(attestationType: AttestationType): List<DocumentMode>
+
     suspend fun getCertificates(): List<String>
 }
 
 class ConfigProviderImpl(private val platformController: PlatformController) : ConfigProvider {
+
+    override val buildType: BuildType
+        get() = platformController.buildType
+
+    override val flavorType: FlavorType
+        get() = platformController.flavorType
+
+    override val appVersion: String
+        get() = "${platformController.appVersion}-${flavorType.name}"
+
     override fun getDocumentModes(attestationType: AttestationType): List<DocumentMode> {
         return when (attestationType) {
             AttestationType.Pid -> listOf(DocumentMode.FULL, DocumentMode.CUSTOM)
@@ -133,7 +154,7 @@ class ConfigProviderImpl(private val platformController: PlatformController) : C
     )
 
     override val logger: Logger
-        get() = when (platformController.buildType) {
+        get() = when (buildType) {
             BuildType.DEBUG -> Logger.LEVEL_DEBUG
             BuildType.RELEASE -> Logger.OFF
         }

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/di/InteractorModule.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/di/InteractorModule.kt
@@ -101,9 +101,11 @@ class InteractorModule {
     fun provideMenuInteractor(
         uuidProvider: UuidProvider,
         resourceProvider: ResourceProvider,
+        configProvider: ConfigProvider
     ): MenuInteractor = MenuInteractorImpl(
         uuidProvider,
         resourceProvider,
+        configProvider
     )
 
     @Factory

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/MenuInteractor.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/MenuInteractor.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.euidi.verifier.domain.interactor
 
 import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
 import eu.europa.ec.euidi.verifier.core.provider.UuidProvider
+import eu.europa.ec.euidi.verifier.domain.config.ConfigProvider
 import eu.europa.ec.euidi.verifier.presentation.component.AppIcons
 import eu.europa.ec.euidi.verifier.presentation.component.ListItemDataUi
 import eu.europa.ec.euidi.verifier.presentation.component.ListItemLeadingContentDataUi
@@ -37,11 +38,13 @@ import kotlinx.coroutines.withContext
 interface MenuInteractor {
     suspend fun getScreenTitle(): String
     suspend fun getMenuItemsUi(): List<MenuItemUi>
+    fun getAppVersion(): String
 }
 
 class MenuInteractorImpl(
     private val uuidProvider: UuidProvider,
     private val resourceProvider: ResourceProvider,
+    private val configProvider: ConfigProvider,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : MenuInteractor {
 
@@ -96,4 +99,6 @@ class MenuInteractorImpl(
             }
         }
     }
+
+    override fun getAppVersion(): String = configProvider.appVersion
 }

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/menu/MenuScreen.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/menu/MenuScreen.kt
@@ -16,6 +16,7 @@
 
 package eu.europa.ec.euidi.verifier.presentation.ui.menu
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -25,11 +26,15 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
@@ -120,21 +125,28 @@ private fun Content(
     onNavigationRequested: (Effect.Navigation) -> Unit,
     paddingValues: PaddingValues,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(paddingValues),
-    ) {
-        ContentTitle(
-            title = state.screenTitle,
-            modifier = Modifier.fillMaxWidth()
-        )
+    Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            ContentTitle(
+                title = state.screenTitle,
+                modifier = Modifier.fillMaxWidth()
+            )
 
-        MenuOptions(
-            menuOptions = state.menuItems,
-            modifier = Modifier.fillMaxSize(),
-            onEventSent = onEventSend,
+            MenuOptions(
+                menuOptions = state.menuItems,
+                modifier = Modifier.fillMaxSize(),
+                onEventSent = onEventSend,
+            )
+        }
+        Text(
+            modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth(),
+            text = state.appVersion,
+            style = MaterialTheme.typography.bodySmall,
+            textAlign = TextAlign.Center
         )
     }
 

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/menu/MenuViewModel.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/menu/MenuViewModel.kt
@@ -37,6 +37,7 @@ sealed interface MenuViewModelContract {
         val isLoading: Boolean,
         val screenTitle: String = "",
         val menuItems: List<MenuItemUi> = emptyList(),
+        val appVersion: String = ""
     ) : UiState
 
     sealed interface Event : UiEvent {
@@ -72,7 +73,7 @@ class MenuViewModel(
 
     override fun createInitialState(): State {
         return State(
-            isLoading = true,
+            isLoading = true
         )
     }
 
@@ -102,6 +103,7 @@ class MenuViewModel(
 
             val titleDeferred = async { interactor.getScreenTitle() }
             val menuItemsDeferred = async { interactor.getMenuItemsUi() }
+            val appVersion = interactor.getAppVersion()
 
             val screenTitle = titleDeferred.await()
             val menuItems = menuItemsDeferred.await()
@@ -110,7 +112,8 @@ class MenuViewModel(
                 copy(
                     screenTitle = screenTitle,
                     menuItems = menuItems,
-                    isLoading = false
+                    isLoading = false,
+                    appVersion = appVersion
                 )
             }
         }

--- a/verifierApp/src/iosMain/kotlin/eu/europa/ec/euidi/verifier/core/controller/IosPlatformController.kt
+++ b/verifierApp/src/iosMain/kotlin/eu/europa/ec/euidi/verifier/core/controller/IosPlatformController.kt
@@ -17,6 +17,7 @@
 package eu.europa.ec.euidi.verifier.core.controller
 
 import eu.europa.ec.euidi.verifier.core.controller.model.BuildType
+import eu.europa.ec.euidi.verifier.core.controller.model.FlavorType
 import platform.Foundation.NSURL
 import platform.UIKit.UIApplication
 import platform.UIKit.UIApplicationOpenSettingsURLString
@@ -25,6 +26,12 @@ class IosPlatformController : PlatformController {
 
     override val buildType: BuildType
         get() = BuildType.DEBUG
+
+    override val flavorType: FlavorType
+        get() = FlavorType.Dev
+
+    override val appVersion: String
+        get() = "yyyy.mm.v"
 
     override fun closeApp() {
         // no-op


### PR DESCRIPTION
This commit introduces the display of the application version in the `MenuScreen`.

Key changes:
- Added `flavorType` and `appVersion` to `PlatformController` and its implementations (`AndroidPlatformController`, `IosPlatformController`).
- `ConfigProvider` now exposes `buildType`, `flavorType`, and `appVersion`. The `appVersion` in `ConfigProviderImpl` is formatted as `"${platformController.appVersion}-${flavorType.name}"`.
- Created `FlavorType.kt` enum with `Dev` and `Public` values.
- `MenuInteractor` now has a `getAppVersion()` method and `MenuInteractorImpl` retrieves it from `ConfigProvider`.
- `MenuViewModel.State` includes `appVersion`.
- `MenuScreen` displays the `appVersion` at the bottom center of the screen.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable