### PR TITLE
Fix silent failures on the QR scan screen

### DIFF
--- a/verifierApp/src/commonMain/composeResources/values/strings.xml
+++ b/verifierApp/src/commonMain/composeResources/values/strings.xml
@@ -205,5 +205,7 @@
 
     <!-- Qr Scan -->
     <string name="qr_scan_screen_title">Device Engagement</string>
+    <string name="qr_scan_screen_error_invalid_code">The scanned QR code is not a supported device engagement code.</string>
+    <string name="qr_scan_screen_error_missing_documents">No documents have been selected to request. Please go back and select at least one document.</string>
 
 </resources>

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/QrScanInteractor.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/QrScanInteractor.kt
@@ -19,6 +19,8 @@ package eu.europa.ec.euidi.verifier.domain.interactor
 import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
 import eu.europa.ec.euidi.verifier.core.utils.Constants
 import eudiverifier.verifierapp.generated.resources.Res
+import eudiverifier.verifierapp.generated.resources.qr_scan_screen_error_invalid_code
+import eudiverifier.verifierapp.generated.resources.qr_scan_screen_error_missing_documents
 import eudiverifier.verifierapp.generated.resources.qr_scan_screen_title
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -28,6 +30,8 @@ import kotlinx.coroutines.withContext
 interface QrScanInteractor {
     suspend fun getScreenTitle(): String
     fun qrCodeIsValid(qrCode: String): Boolean
+    suspend fun getInvalidQrCodeMessage(): String
+    suspend fun getMissingDocumentsMessage(): String
 }
 
 class QrScanInteractorImpl(
@@ -43,5 +47,17 @@ class QrScanInteractorImpl(
 
     override fun qrCodeIsValid(qrCode: String): Boolean {
         return qrCode.startsWith(prefix = Constants.Generic.MDOC_PREFIX, ignoreCase = true)
+    }
+
+    override suspend fun getInvalidQrCodeMessage(): String {
+        return withContext(dispatcher) {
+            resourceProvider.getSharedString(Res.string.qr_scan_screen_error_invalid_code)
+        }
+    }
+
+    override suspend fun getMissingDocumentsMessage(): String {
+        return withContext(dispatcher) {
+            resourceProvider.getSharedString(Res.string.qr_scan_screen_error_missing_documents)
+        }
     }
 }

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/qr_scan/QrScanViewModel.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/qr_scan/QrScanViewModel.kt
@@ -77,11 +77,7 @@ class QrScanViewModel(
         when (event) {
             is Event.Init -> {
                 setScreenTitle()
-
-                event.docs?.let { safeDocs ->
-                    setDocuments(safeDocs)
-                } //TODO what happens if docs are null?
-
+                handleInitialDocuments(docs = event.docs)
             }
 
             is Event.OnBackClicked -> {
@@ -97,7 +93,6 @@ class QrScanViewModel(
             }
 
             is Event.OnQrScanFailed -> {
-                handleQrScanned(qrCode = null)
                 handleQrScanFailed(error = event.error)
             }
         }
@@ -122,6 +117,15 @@ class QrScanViewModel(
         }
     }
 
+    private fun handleInitialDocuments(docs: List<RequestedDocumentUi>?) {
+        if (docs.isNullOrEmpty()) {
+            setState { copy(finishedScanning = true) }
+            showError { interactor.getMissingDocumentsMessage() }
+        } else {
+            setDocuments(docs)
+        }
+    }
+
     private fun goToTransferStatusScreen(qrCode: String) {
         setEffect {
             Effect.Navigation.NavigateToTransferStatusScreen(
@@ -133,36 +137,49 @@ class QrScanViewModel(
         }
     }
 
-    private fun handleQrScanFailed(error: String) {
-        setState {
-            copy(
-                error = ContentErrorConfig(
-                    errorSubTitle = error,
-                    onCancel = {
-                        setEvent(Event.DismissError)
-                        goBack()
-                    }
-                )
-            )
-        }
-    }
-
-    private fun handleQrScanned(qrCode: String?) {
+    private fun handleQrScanned(qrCode: String) {
         if (uiState.value.finishedScanning) {
             return
         }
 
-        qrCode?.let { safeQrCode ->
-            if (!interactor.qrCodeIsValid(safeQrCode)) {
-                return
-            }
+        setState { copy(finishedScanning = true) }
 
-            setState {
-                copy(finishedScanning = true)
-            }
-            goToTransferStatusScreen(safeQrCode)
+        if (interactor.qrCodeIsValid(qrCode)) {
+            goToTransferStatusScreen(qrCode)
+        } else {
+            showError { interactor.getInvalidQrCodeMessage() }
         }
     }
+
+    private fun handleQrScanFailed(error: String) {
+        if (uiState.value.error != null) {
+            return
+        }
+        setState {
+            copy(
+                finishedScanning = true,
+                error = buildErrorConfig(errorSubTitle = error)
+            )
+        }
+    }
+
+    private fun showError(message: suspend () -> String) {
+        viewModelScope.launch {
+            val resolvedMessage = message()
+            setState {
+                copy(error = buildErrorConfig(errorSubTitle = resolvedMessage))
+            }
+        }
+    }
+
+    private fun buildErrorConfig(errorSubTitle: String): ContentErrorConfig =
+        ContentErrorConfig(
+            errorSubTitle = errorSubTitle,
+            onCancel = {
+                setEvent(Event.DismissError)
+                goBack()
+            }
+        )
 
     private fun goBack() {
         setEffect { Effect.Navigation.Pop }


### PR DESCRIPTION
## Problem

`QrScanViewModel` gave the user no feedback in two cases:

1. The screen was opened without any documents to request (`Event.Init` with `null` or an empty list) — it would proceed to a device engagement requesting nothing. This was flagged by an existing `//TODO` in the code.
2. A QR code was decoded successfully but was not a supported device engagement code — `handleQrScanned` returned silently, leaving the user on a live camera.

## Changes

- `QrScanViewModel`
  - `Event.Init` now routes through `handleInitialDocuments`, which surfaces an error via `ContentErrorConfig` when there are no documents instead of proceeding silently. Resolves the existing `//TODO`.
  - `handleQrScanned` surfaces an error for decoded-but-unsupported codes through the same `ContentErrorConfig` mechanism.
  - Scanning is marked finished synchronously when a code is received. The camera emits a callback per frame, so doing this synchronously prevents the same code being processed repeatedly and guards against re-entrancy on the asynchronous error path.
  - Error construction is extracted into a single `buildErrorConfig` helper, reused by both new error paths and the existing decode-failure path.
  - Removed a dead `handleQrScanned(qrCode = null)` call from the `OnQrScanFailed` branch.
- `QrScanInteractor` — added `getInvalidQrCodeMessage()` and `getMissingDocumentsMessage()`, mirroring the existing `getScreenTitle()` pattern (`suspend` + `withContext(dispatcher)`).
- `strings.xml` — added `qr_scan_screen_error_invalid_code` and `qr_scan_screen_error_missing_documents`.

## Testing

- `./gradlew :verifierApp:allTests` — passes on Android JVM and iOS Simulator.
- Manually verified scanning a non-`mdoc:` QR code now shows an error instead of doing nothing.