### PR TITLE
Introduce Mokkery for mocking and expand interactor test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # EUDI Multiplatform Verifier Application
 
 [![License: EUPL 1.2](https://img.shields.io/badge/License-EUPL%201.2-blue.svg)](https://joinup.ec.europa.eu/software/page/eupl)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-7F52FF.svg?logo=kotlin)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.20-7F52FF.svg?logo=kotlin)](https://kotlinlang.org)
 [![Compose Multiplatform](https://img.shields.io/badge/Compose%20Multiplatform-1.11-4285F4.svg)](https://www.jetbrains.com/lp/compose-multiplatform/)
 [![Android API](https://img.shields.io/badge/Android%20API-29%2B-3DDC84.svg?logo=android)](https://developer.android.com/about/versions/10)
 [![iOS](https://img.shields.io/badge/iOS-18.6%2B-000000.svg?logo=apple)](https://developer.apple.com/ios/)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,4 +26,5 @@ plugins {
     alias(libs.plugins.kover) apply false
     alias(libs.plugins.kotlinMultiplatformLibrary) apply false
     alias(libs.plugins.kotlinAndroid) apply false
+    alias(libs.plugins.mokkery) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,8 @@
 [versions]
-kotlin = "2.3.21"
+kotlin = "2.3.20"
+mokkery = "3.3.0"
 kotlinxCoroutinesTest = "1.11.0"
-ksp = "2.3.4"
+ksp = "2.3.9"
 agp = "9.2.1"
 composeMultiplatform = "1.11.0"
 androidx-activity = "1.13.0"
@@ -83,3 +84,4 @@ kotlinParcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = 
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+mokkery = { id = "dev.mokkery", version.ref = "mokkery" }

--- a/verifierApp/build.gradle.kts
+++ b/verifierApp/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
     alias(libs.plugins.kotlinParcelize)
     alias(libs.plugins.serialization)
     alias(libs.plugins.kover)
+    alias(libs.plugins.mokkery)
 }
 
 val sdkVersion: String by project

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/CustomRequestInteractor.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/CustomRequestInteractor.kt
@@ -73,10 +73,9 @@ class CustomRequestInteractorImpl(
         withContext(dispatcher) {
             items
                 .filter { uiItem ->
-                    (uiItem.trailingContentData as? ListItemTrailingContentDataUi.Checkbox)
-                        ?.checkboxData
-                        ?.isChecked
-                        ?: false
+                    val trailingContentData = uiItem.trailingContentData
+                    trailingContentData is ListItemTrailingContentDataUi.Checkbox &&
+                            trailingContentData.checkboxData.isChecked
                 }
                 .map { uiItem ->
                     ClaimItem(label = uiItem.itemId)

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/DocumentsToRequestInteractor.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/DocumentsToRequestInteractor.kt
@@ -91,8 +91,10 @@ class DocumentsToRequestInteractorImpl(
 
             // Case 2: Custom mode → remove FULL if exists, then navigate
             if (mode == DocumentMode.CUSTOM) {
+                // Case 1 above already returned for any (docId, CUSTOM) match, so any remaining
+                // doc sharing this id is necessarily in FULL mode.
                 val updated =
-                    if (currentDocs.any { it.id == docId && it.mode == DocumentMode.FULL }) {
+                    if (currentDocs.any { it.id == docId }) {
                         currentDocs.filterNot { it.id == docId }
                     } else {
                         currentDocs

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/SettingsInteractor.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/SettingsInteractor.kt
@@ -156,7 +156,7 @@ class SettingsInteractorImpl(
 
     private fun buildSection(
         headerTitle: StringResource,
-        headerDesc: StringResource? = null,
+        headerDesc: StringResource?,
         sectionItems: List<SettingsTypeUi>,
         preferences: Map<PrefKey, Boolean>
     ): List<SettingsItemUi> {
@@ -172,7 +172,7 @@ class SettingsInteractorImpl(
             // each item
             sectionItems.forEachIndexed { index, sectionItem ->
                 val isLast = index == sectionItems.lastIndex
-                val checked = preferences[sectionItem.prefKey] ?: false
+                val checked = preferences.getValue(sectionItem.prefKey)
                 val supportingText = resourceProvider.getSharedString(
                     if (checked) {
                         sectionItem.selectedDescriptionRes

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/CustomRequestInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/CustomRequestInteractorTest.kt
@@ -16,6 +16,11 @@
 
 package eu.europa.ec.euidi.verifier.domain.interactor
 
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
 import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
 import eu.europa.ec.euidi.verifier.domain.config.ConfigProvider
 import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType
@@ -26,7 +31,6 @@ import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDat
 import eu.europa.ec.euidi.verifier.presentation.component.ListItemTrailingContentDataUi
 import eu.europa.ec.euidi.verifier.presentation.component.wrap.CheckboxDataUi
 import eudiverifier.verifierapp.generated.resources.Res
-import eudiverifier.verifierapp.generated.resources.custom_request_screen_title
 import eudiverifier.verifierapp.generated.resources.document_type_employee_id
 import eudiverifier.verifierapp.generated.resources.document_type_mdl
 import eudiverifier.verifierapp.generated.resources.document_type_pid
@@ -48,24 +52,24 @@ class CustomRequestInteractorTest {
      * dispatcher that shares the `runTest` scheduler. This ensures that coroutines launched
      * by the interactor run deterministically within the test's scope.
      *
-     * It initializes the interactor with optional fake configurations and a resource provider,
+     * It initializes the interactor with Mokkery mocks for its collaborators,
      * making it easy to set up different test scenarios.
      *
      * @param supportedDocuments The configuration of supported documents and their claims.
      * Defaults to an empty configuration.
-     * @param resourceProvider The provider for retrieving string resources. Defaults to a
-     * [FakeResourceProvider].
+     * @param resourceProvider The provider for retrieving string resources. Defaults to the
+     * mock built by [stringResourceProvider].
      * @return An instance of [CustomRequestInteractorImpl] configured for testing.
      */
     private fun TestScope.createInteractor(
         supportedDocuments: SupportedDocuments = SupportedDocuments(emptyMap()),
-        resourceProvider: ResourceProvider = FakeResourceProvider
+        resourceProvider: ResourceProvider = stringResourceProvider()
     ): CustomRequestInteractor {
         // Use the dispatcher that runTest is already using
         val testDispatcher = coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
 
         return CustomRequestInteractorImpl(
-            configProvider = FakeConfigProvider(supportedDocuments),
+            configProvider = configProvider(supportedDocuments),
             resourceProvider = resourceProvider,
             dispatcher = testDispatcher
         )
@@ -80,9 +84,8 @@ class CustomRequestInteractorTest {
 
             val result = interactor.getScreenTitle(AttestationType.Pid)
 
-            // FakeResourceProvider is defined to:
-            // - map PID -> "PID"
-            // - map custom_request_screen_title -> "CustomRequestTitle(label)"
+            // The resource provider mock maps PID -> "PID" and the title's vararg overload
+            // -> "CustomRequestTitle(PID)".
             assertEquals("CustomRequestTitle(PID)", result)
         }
 
@@ -182,8 +185,7 @@ class CustomRequestInteractorTest {
             )
 
             val interactor = createInteractor(
-                supportedDocuments = SupportedDocuments(emptyMap()),
-                resourceProvider = FakeResourceProvider
+                supportedDocuments = SupportedDocuments(emptyMap())
             )
 
             // WHEN
@@ -272,6 +274,23 @@ class CustomRequestInteractorTest {
             assertFalse(result.hasSelectedItems)
         }
 
+    @Test
+    fun `handleItemSelection leaves a matched item without a checkbox unchanged`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor()
+
+            val noCheckbox = listItemWithoutCheckbox(id = "id_1")
+
+            val result = interactor.handleItemSelection(
+                items = listOf(noCheckbox),
+                identifier = "id_1"
+            ) as HandleItemSelectionPartialState.Updated
+
+            // The id matches but the item has no checkbox, so it is returned unchanged.
+            assertEquals(noCheckbox, result.items.single())
+            assertFalse(result.hasSelectedItems)
+        }
+
     // endregion
 
     // region helpers
@@ -303,69 +322,33 @@ class CustomRequestInteractorTest {
 
     // endregion
 
-    // region Fakes
+    // region Mocks
 
-    /**
-     * Very small fake ConfigProvider for these tests.
-     *
-     * Note: we don't need to construct BuildType, FlavorType, DocumentMode, or Logger,
-     * so getters just throw if accessed. The interactor only uses supportedDocuments.
-     */
-    private class FakeConfigProvider(
-        override val supportedDocuments: SupportedDocuments
-    ) : ConfigProvider {
-
-        override val buildType
-            get() = error("Not used in these tests")
-
-        override val flavorType
-            get() = error("Not used in these tests")
-
-        override val appVersion: String
-            get() = "test"
-
-        override val logger
-            get() = error("Not used in these tests")
-
-        override fun getDocumentModes(attestationType: AttestationType) =
-            error("Not used in these tests")
-
-        override suspend fun getCertificates(): List<String> =
-            error("Not used in these tests")
+    private fun configProvider(supportedDocuments: SupportedDocuments): ConfigProvider {
+        val configProvider = mock<ConfigProvider>()
+        every { configProvider.supportedDocuments } returns supportedDocuments
+        return configProvider
     }
 
     /**
-     * Simple fake ResourceProvider that returns predictable strings
-     * so we can assert on them in tests.
+     * Mocks the [ResourceProvider]. The single-argument overload maps the document-type labels and
+     * returns a non-empty fallback for the dynamic claim translations resolved by `UiTransformer`.
+     * The vararg overload backs `getScreenTitle`, whose only test exercises the PID document.
      */
-    private object FakeResourceProvider : ResourceProvider {
-
-        override fun getSharedString(resource: StringResource): String {
-            return when (resource) {
+    private fun stringResourceProvider(): ResourceProvider {
+        val resourceProvider = mock<ResourceProvider>()
+        every { resourceProvider.getSharedString(any()) } calls { (resource: StringResource) ->
+            when (resource) {
                 Res.string.document_type_pid -> "PID"
                 Res.string.document_type_mdl -> "MDL"
                 Res.string.document_type_employee_id -> "EMPLOYEE_ID"
-                else -> "UNKNOWN_STRING"
+                else -> "translated"
             }
         }
-
-        override fun getSharedString(
-            resource: StringResource,
-            vararg formatArgs: Any
-        ): String {
-            return when (resource) {
-                Res.string.custom_request_screen_title -> {
-                    val label = formatArgs.firstOrNull() as? String ?: ""
-                    "CustomRequestTitle($label)"
-                }
-
-                else -> "UNKNOWN_FORMATTED_STRING(${formatArgs.joinToString()})"
-            }
-        }
-
-        override fun genericErrorMessage(): String = "GENERIC_ERROR"
-
-        override fun genericNetworkErrorMessage(): String = "GENERIC_NETWORK_ERROR"
+        every {
+            resourceProvider.getSharedString(any(), *any())
+        } returns "CustomRequestTitle(PID)"
+        return resourceProvider
     }
 
     // endregion

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/DocumentsToRequestInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/DocumentsToRequestInteractorTest.kt
@@ -16,10 +16,12 @@
 
 package eu.europa.ec.euidi.verifier.domain.interactor
 
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
 import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
 import eu.europa.ec.euidi.verifier.domain.config.ConfigProvider
 import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType
-import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType.Companion.getDisplayName
 import eu.europa.ec.euidi.verifier.domain.config.model.ClaimItem
 import eu.europa.ec.euidi.verifier.domain.config.model.DocumentMode
 import eu.europa.ec.euidi.verifier.domain.config.model.SupportedDocuments
@@ -34,7 +36,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import org.jetbrains.compose.resources.StringResource
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -55,8 +56,8 @@ class DocumentsToRequestInteractorTest {
     ): DocumentsToRequestInteractor {
         val dispatcher = coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
         return DocumentsToRequestInteractorImpl(
-            configProvider = FakeConfigProvider(supportedDocuments),
-            resourceProvider = FakeResourceProvider,
+            configProvider = configProvider(supportedDocuments),
+            resourceProvider = stringResourceProvider(),
             dispatcher = dispatcher
         )
     }
@@ -302,6 +303,107 @@ class DocumentsToRequestInteractorTest {
             assertTrue(result.docs.any { it.documentType == AttestationType.Pid })
         }
 
+    @Test
+    fun `handleDocumentOptionSelection removes only the matching type and mode when already selected`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor()
+            val currentDocs = listOf(
+                RequestedDocumentUi(
+                    id = "PID_DOC",
+                    documentType = AttestationType.Pid,
+                    mode = DocumentMode.FULL,
+                    claims = emptyList()
+                ),
+                RequestedDocumentUi(
+                    id = "PID_CUSTOM",
+                    documentType = AttestationType.Pid,
+                    mode = DocumentMode.CUSTOM,
+                    claims = emptyList()
+                ),
+                RequestedDocumentUi(
+                    id = "MDL_DOC",
+                    documentType = AttestationType.Mdl,
+                    mode = DocumentMode.FULL,
+                    claims = emptyList()
+                )
+            )
+
+            val result = interactor.handleDocumentOptionSelection(
+                currentDocs = currentDocs,
+                docId = "PID_DOC",
+                docType = AttestationType.Pid,
+                mode = DocumentMode.FULL
+            ) as DocSelectionResult.Updated
+
+            // Only the PID/FULL doc is removed; the PID/CUSTOM and MDL/FULL docs remain.
+            assertEquals(2, result.docs.size)
+            assertTrue(
+                result.docs.any {
+                    it.documentType == AttestationType.Pid && it.mode == DocumentMode.CUSTOM
+                }
+            )
+            assertTrue(result.docs.any { it.documentType == AttestationType.Mdl })
+        }
+
+    @Test
+    fun `handleDocumentOptionSelection custom mode keeps unrelated docs when navigating`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor()
+            val currentDocs = listOf(
+                RequestedDocumentUi(
+                    id = "MDL_DOC",
+                    documentType = AttestationType.Mdl,
+                    mode = DocumentMode.FULL,
+                    claims = emptyList()
+                )
+            )
+
+            val result = interactor.handleDocumentOptionSelection(
+                currentDocs = currentDocs,
+                docId = "PID_DOC",
+                docType = AttestationType.Pid,
+                mode = DocumentMode.CUSTOM
+            ) as DocSelectionResult.NavigateToCustomRequest
+
+            // No doc shares the id, so nothing is removed before navigating.
+            assertEquals(currentDocs, result.docs)
+            assertEquals(DocumentMode.CUSTOM, result.customDoc.mode)
+        }
+
+    @Test
+    fun `handleDocumentOptionSelection full mode appends when same type and mode exist under another id`() =
+        runTest(StandardTestDispatcher()) {
+            val pidClaims = listOf(ClaimItem("family_name"))
+            val supportedDocs = SupportedDocuments(
+                documents = mapOf(AttestationType.Pid to pidClaims)
+            )
+            val interactor = createInteractor(supportedDocs)
+
+            val currentDocs = listOf(
+                RequestedDocumentUi(
+                    id = "PID_OTHER",
+                    documentType = AttestationType.Pid,
+                    mode = DocumentMode.FULL,
+                    claims = pidClaims
+                )
+            )
+
+            val result = interactor.handleDocumentOptionSelection(
+                currentDocs = currentDocs,
+                docId = "PID_DOC",
+                docType = AttestationType.Pid,
+                mode = DocumentMode.FULL
+            ) as DocSelectionResult.Updated
+
+            // No existing PID doc has a *different* mode, so none are filtered out; the new doc is appended.
+            assertEquals(2, result.docs.size)
+            assertTrue(
+                result.docs.all {
+                    it.documentType == AttestationType.Pid && it.mode == DocumentMode.FULL
+                }
+            )
+        }
+
     // endregion
 
     // region searchDocuments
@@ -311,12 +413,12 @@ class DocumentsToRequestInteractorTest {
         runTest(StandardTestDispatcher()) {
             val docs = listOf(
                 SupportedDocumentUi(
-                    id = AttestationType.Pid.getDisplayName(FakeResourceProvider),
+                    id = "PID",
                     documentType = AttestationType.Pid,
                     modes = listOf(DocumentMode.FULL)
                 ),
                 SupportedDocumentUi(
-                    id = AttestationType.Mdl.getDisplayName(FakeResourceProvider),
+                    id = "MDL",
                     documentType = AttestationType.Mdl,
                     modes = listOf(DocumentMode.CUSTOM)
                 )
@@ -338,12 +440,12 @@ class DocumentsToRequestInteractorTest {
         runTest(StandardTestDispatcher()) {
             val docs = listOf(
                 SupportedDocumentUi(
-                    id = AttestationType.Pid.getDisplayName(FakeResourceProvider),
+                    id = "PID",
                     documentType = AttestationType.Pid,
                     modes = listOf(DocumentMode.FULL)
                 ),
                 SupportedDocumentUi(
-                    id = AttestationType.Mdl.getDisplayName(FakeResourceProvider),
+                    id = "MDL",
                     documentType = AttestationType.Mdl,
                     modes = listOf(DocumentMode.CUSTOM)
                 )
@@ -498,53 +600,54 @@ class DocumentsToRequestInteractorTest {
             assertEquals(DocumentMode.CUSTOM, updated.mode)
         }
 
+    @Test
+    fun `checkDocumentMode keeps mode when document type is not configured`() =
+        runTest(StandardTestDispatcher()) {
+            // Empty supported documents -> expected claim count resolves to 0 via the elvis fallback,
+            // so a doc with claims never matches and the mode is kept.
+            val interactor = createInteractor()
+
+            val requestedDocs = listOf(
+                RequestedDocumentUi(
+                    id = "PID_DOC",
+                    documentType = AttestationType.Pid,
+                    mode = DocumentMode.CUSTOM,
+                    claims = listOf(ClaimItem("family_name"))
+                )
+            )
+
+            val result = interactor.checkDocumentMode(requestedDocs)
+
+            assertEquals(DocumentMode.CUSTOM, result.single().mode)
+        }
+
     // endregion
 
-    // region Fakes
+    // region Mocks
 
-    private class FakeConfigProvider(
-        override val supportedDocuments: SupportedDocuments
-    ) : ConfigProvider {
-
-        override val buildType
-            get() = error("Not used in these tests")
-
-        override val flavorType
-            get() = error("Not used in these tests")
-
-        override val appVersion: String
-            get() = "test"
-
-        override val logger
-            get() = error("Not used in these tests")
-
-        override fun getDocumentModes(attestationType: AttestationType): List<DocumentMode> =
-            when (attestationType) {
-                AttestationType.Pid -> listOf(DocumentMode.FULL, DocumentMode.CUSTOM)
-                AttestationType.Mdl -> listOf(DocumentMode.FULL)
-                AttestationType.EmployeeId -> emptyList()
-            }
-
-        override suspend fun getCertificates(): List<String> =
-            error("Not used in these tests")
+    private fun configProvider(supportedDocuments: SupportedDocuments): ConfigProvider {
+        val configProvider = mock<ConfigProvider>()
+        every { configProvider.supportedDocuments } returns supportedDocuments
+        every {
+            configProvider.getDocumentModes(AttestationType.Pid)
+        } returns listOf(DocumentMode.FULL, DocumentMode.CUSTOM)
+        every {
+            configProvider.getDocumentModes(AttestationType.Mdl)
+        } returns listOf(DocumentMode.FULL)
+        every {
+            configProvider.getDocumentModes(AttestationType.EmployeeId)
+        } returns emptyList()
+        return configProvider
     }
 
-    private object FakeResourceProvider : ResourceProvider {
-
-        override fun getSharedString(resource: StringResource): String =
-            when (resource) {
-                Res.string.document_type_pid -> "PID"
-                Res.string.document_type_mdl -> "MDL"
-                Res.string.document_type_employee_id -> "EMPLOYEE_ID"
-                else -> "UNKNOWN_STRING"
-            }
-
-        override fun getSharedString(resource: StringResource, vararg formatArgs: Any): String =
-            getSharedString(resource)
-
-        override fun genericErrorMessage(): String = "GENERIC_ERROR"
-
-        override fun genericNetworkErrorMessage(): String = "GENERIC_NETWORK_ERROR"
+    private fun stringResourceProvider(): ResourceProvider {
+        val resourceProvider = mock<ResourceProvider>()
+        every { resourceProvider.getSharedString(Res.string.document_type_pid) } returns "PID"
+        every { resourceProvider.getSharedString(Res.string.document_type_mdl) } returns "MDL"
+        every {
+            resourceProvider.getSharedString(Res.string.document_type_employee_id)
+        } returns "EMPLOYEE_ID"
+        return resourceProvider
     }
 
     // endregion

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/HomeInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/HomeInteractorTest.kt
@@ -16,6 +16,13 @@
 
 package eu.europa.ec.euidi.verifier.domain.interactor
 
+import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
 import eu.europa.ec.euidi.verifier.core.controller.PlatformController
 import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
 import eu.europa.ec.euidi.verifier.core.provider.UuidProvider
@@ -37,7 +44,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import org.jetbrains.compose.resources.StringResource
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -46,54 +52,41 @@ import kotlin.test.assertIs
 class HomeInteractorTest {
 
     /**
-     * A test factory function for creating an instance of [HomeInteractor] with its dependencies,
-     * suitable for use within a [TestScope].
-     *
-     * This function simplifies the setup of the interactor for testing by providing default fake
-     * implementations for its dependencies. The fakes can be overridden by passing in specific
-     * instances.
-     *
-     * @param platformController A [FakePlatformController] instance. Defaults to a new instance.
-     * @param uuidProvider A [UuidProvider] instance. Defaults to a [FakeUuidProvider].
-     * @param resourceProvider A [ResourceProvider] instance. Defaults to a [FakeResourceProvider].
-     * @return A [Pair] containing the created [HomeInteractor] instance and the
-     * [FakePlatformController] used, allowing for verification of interactions with the platform.
+     * Builds the SUT, [HomeInteractorImpl], with a dispatcher that shares the `runTest` scheduler
+     * and Mokkery mocks for its collaborators. Pass overrides to customise behaviour or to verify
+     * interactions (e.g. the [PlatformController]).
      */
     private fun TestScope.createInteractor(
-        platformController: FakePlatformController = FakePlatformController(),
-        uuidProvider: UuidProvider = FakeUuidProvider(),
-        resourceProvider: ResourceProvider = FakeResourceProvider(),
-    ): Pair<HomeInteractor, FakePlatformController> {
+        platformController: PlatformController = mock<PlatformController>(MockMode.autoUnit),
+        uuidProvider: UuidProvider = sequentialUuidProvider(),
+        resourceProvider: ResourceProvider = stringResourceProvider(),
+    ): HomeInteractor {
         val dispatcher = coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
-
-        val interactor = HomeInteractorImpl(
+        return HomeInteractorImpl(
             platformController = platformController,
             uuidProvider = uuidProvider,
             resourceProvider = resourceProvider,
             dispatcher = dispatcher
         )
-
-        return Pair(interactor, platformController)
     }
 
     //region getScreenTitle
 
     @Test
     fun `getScreenTitle returns localized title`() = runTest(StandardTestDispatcher()) {
-        val (interactor, _) = createInteractor()
+        val interactor = createInteractor()
 
-        val title = interactor.getScreenTitle()
-
-        assertEquals("Home Screen title", title)
+        assertEquals("Home Screen title", interactor.getScreenTitle())
     }
 
     //endregion
 
     //region getDefaultMainButtonData
+
     @Test
     fun `getDefaultMainButtonData uses uuidProvider default text and chevron icon`() =
         runTest(StandardTestDispatcher()) {
-            val (interactor, _) = createInteractor()
+            val interactor = createInteractor()
 
             val item = interactor.getDefaultMainButtonData()
 
@@ -118,7 +111,7 @@ class HomeInteractorTest {
     @Test
     fun `formatMainButtonData formats single requested document`() =
         runTest(StandardTestDispatcher()) {
-            val (interactor, _) = createInteractor()
+            val interactor = createInteractor()
 
             val baseItem = ListItemDataUi(
                 itemId = "base-id",
@@ -158,7 +151,7 @@ class HomeInteractorTest {
     @Test
     fun `formatMainButtonData joins multiple requested documents with separator`() =
         runTest(StandardTestDispatcher()) {
-            val (interactor, _) = createInteractor()
+            val interactor = createInteractor()
 
             val baseItem = ListItemDataUi(
                 itemId = "base-id",
@@ -199,87 +192,36 @@ class HomeInteractorTest {
     //region closeApp
 
     @Test
-    fun `closeApp delegates to PlatformController`() =
-        runTest(StandardTestDispatcher()) {
-            val (interactor, fakePlatformController) = createInteractor()
+    fun `closeApp delegates to PlatformController`() = runTest(StandardTestDispatcher()) {
+        val platformController = mock<PlatformController>(MockMode.autoUnit)
+        val interactor = createInteractor(platformController = platformController)
 
-            assertEquals(0, fakePlatformController.closeAppCalls)
+        interactor.closeApp()
 
-            interactor.closeApp()
-
-            assertEquals(1, fakePlatformController.closeAppCalls)
-            assertEquals(0, fakePlatformController.openAppSettingsCalls)
-        }
+        verify(exactly(1)) { platformController.closeApp() }
+        verify(exactly(0)) { platformController.openAppSettings() }
+    }
 
     //endregion
 
-    //region Fakes
+    //region Mocks
 
-    private class FakePlatformController : PlatformController {
-
-        private enum class Function {
-            CLOSE_APP,
-            OPEN_APP_SETTINGS
-        }
-
-        private val functionCallCounts: MutableMap<Function, Int> = mutableMapOf()
-
-        override val buildType
-            get() = error("Not used in these tests")
-
-        override val flavorType
-            get() = error("Not used in these tests")
-
-        override val appVersion: String
-            get() = error("Not used in these tests")
-
-        val closeAppCalls: Int
-            get() = functionCallCounts[Function.CLOSE_APP] ?: 0
-
-        val openAppSettingsCalls: Int
-            get() = functionCallCounts[Function.OPEN_APP_SETTINGS] ?: 0
-
-        override fun closeApp() {
-            functionCallCounts[Function.CLOSE_APP] =
-                (functionCallCounts[Function.CLOSE_APP] ?: 0) + 1
-        }
-
-        override fun openAppSettings() {
-            functionCallCounts[Function.OPEN_APP_SETTINGS] =
-                (functionCallCounts[Function.OPEN_APP_SETTINGS] ?: 0) + 1
+    private fun sequentialUuidProvider(): UuidProvider {
+        var counter = 0
+        return mock {
+            every { provideUuid() } calls { "uuid-${counter++}" }
         }
     }
 
-    private class FakeUuidProvider : UuidProvider {
-        private var counter = 0
-
-        override fun provideUuid(): String {
-            return "uuid-${counter++}"
-        }
-    }
-
-    private class FakeResourceProvider : ResourceProvider {
-
-        override fun getSharedString(resource: StringResource): String {
-            return when (resource) {
-                Res.string.home_screen_title -> "Home Screen title"
-                Res.string.home_screen_main_button_text_default -> "Home Screen main button text default"
-                Res.string.home_screen_main_button_text_separator -> " ; "
-                Res.string.document_type_pid -> "PID"
-                Res.string.document_type_mdl -> "MDL"
-                Res.string.document_type_employee_id -> "Employee ID"
-                else -> "Unknown string"
-            }
-        }
-
-        override fun getSharedString(
-            resource: StringResource,
-            vararg formatArgs: Any
-        ): String = getSharedString(resource)
-
-        override fun genericErrorMessage(): String = "GENERIC_ERROR"
-
-        override fun genericNetworkErrorMessage(): String = "GENERIC_NETWORK_ERROR"
+    private fun stringResourceProvider(): ResourceProvider = mock {
+        every { getSharedString(Res.string.home_screen_title) } returns "Home Screen title"
+        every {
+            getSharedString(Res.string.home_screen_main_button_text_default)
+        } returns "Home Screen main button text default"
+        every { getSharedString(Res.string.home_screen_main_button_text_separator) } returns " ; "
+        every { getSharedString(Res.string.document_type_pid) } returns "PID"
+        every { getSharedString(Res.string.document_type_mdl) } returns "MDL"
+        every { getSharedString(Res.string.document_type_employee_id) } returns "Employee ID"
     }
 
     //endregion

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/MenuInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/MenuInteractorTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.domain.interactor
+
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
+import eu.europa.ec.euidi.verifier.core.provider.UuidProvider
+import eu.europa.ec.euidi.verifier.domain.config.ConfigProvider
+import eu.europa.ec.euidi.verifier.presentation.component.AppIcons
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemLeadingContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemTrailingContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.ui.menu.model.MenuTypeUi
+import eudiverifier.verifierapp.generated.resources.Res
+import eudiverifier.verifierapp.generated.resources.menu_screen_item_home_name
+import eudiverifier.verifierapp.generated.resources.menu_screen_item_settings_name
+import eudiverifier.verifierapp.generated.resources.menu_screen_title
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class MenuInteractorTest {
+
+    /**
+     * Builds the SUT, [MenuInteractorImpl], with a dispatcher that shares the `runTest` scheduler
+     * and Mokkery mocks for its collaborators.
+     */
+    private fun TestScope.createInteractor(
+        uuidProvider: UuidProvider = sequentialUuidProvider(),
+        resourceProvider: ResourceProvider = stringResourceProvider(),
+        configProvider: ConfigProvider = configProvider(version = "1.0.0-Dev"),
+    ): MenuInteractor {
+        val dispatcher = coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
+        return MenuInteractorImpl(
+            uuidProvider = uuidProvider,
+            resourceProvider = resourceProvider,
+            configProvider = configProvider,
+            dispatcher = dispatcher
+        )
+    }
+
+    //region getScreenTitle
+
+    @Test
+    fun `getScreenTitle returns localized title`() = runTest(StandardTestDispatcher()) {
+        val interactor = createInteractor()
+
+        assertEquals("Menu title", interactor.getScreenTitle())
+    }
+
+    //endregion
+
+    //region getMenuItemsUi
+
+    @Test
+    fun `getMenuItemsUi returns home and settings items in order`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor()
+
+            val items = interactor.getMenuItemsUi()
+
+            assertEquals(2, items.size)
+
+            // Home item
+            val home = items[0]
+            assertEquals(MenuTypeUi.HOME, home.type)
+            assertEquals("uuid-0", home.data.itemId)
+
+            val homeMain = home.data.mainContentData
+            assertIs<ListItemMainContentDataUi.Text>(homeMain)
+            assertEquals("Home", homeMain.text)
+
+            val homeLeading = home.data.leadingContentData
+            assertIs<ListItemLeadingContentDataUi.Icon>(homeLeading)
+            assertEquals(AppIcons.Home, homeLeading.iconData)
+
+            val homeTrailing = home.data.trailingContentData
+            assertIs<ListItemTrailingContentDataUi.Icon>(homeTrailing)
+            assertEquals(AppIcons.ChevronRight, homeTrailing.iconData)
+
+            // Settings item
+            val settings = items[1]
+            assertEquals(MenuTypeUi.SETTINGS, settings.type)
+            assertEquals("uuid-1", settings.data.itemId)
+
+            val settingsMain = settings.data.mainContentData
+            assertIs<ListItemMainContentDataUi.Text>(settingsMain)
+            assertEquals("Settings", settingsMain.text)
+
+            val settingsLeading = settings.data.leadingContentData
+            assertIs<ListItemLeadingContentDataUi.Icon>(settingsLeading)
+            assertEquals(AppIcons.Settings, settingsLeading.iconData)
+
+            val settingsTrailing = settings.data.trailingContentData
+            assertIs<ListItemTrailingContentDataUi.Icon>(settingsTrailing)
+            assertEquals(AppIcons.ChevronRight, settingsTrailing.iconData)
+        }
+
+    //endregion
+
+    //region getAppVersion
+
+    @Test
+    fun `getAppVersion delegates to configProvider`() = runTest(StandardTestDispatcher()) {
+        val interactor = createInteractor(
+            configProvider = configProvider(version = "9.9.9-Dev")
+        )
+
+        assertEquals("9.9.9-Dev", interactor.getAppVersion())
+    }
+
+    //endregion
+
+    //region Mocks
+
+    private fun sequentialUuidProvider(): UuidProvider {
+        var counter = 0
+        return mock {
+            every { provideUuid() } calls { "uuid-${counter++}" }
+        }
+    }
+
+    private fun stringResourceProvider(): ResourceProvider = mock {
+        every { getSharedString(Res.string.menu_screen_title) } returns "Menu title"
+        every { getSharedString(Res.string.menu_screen_item_home_name) } returns "Home"
+        every { getSharedString(Res.string.menu_screen_item_settings_name) } returns "Settings"
+    }
+
+    private fun configProvider(version: String): ConfigProvider {
+        val configProvider = mock<ConfigProvider>()
+        every { configProvider.appVersion } returns version
+        return configProvider
+    }
+
+    //endregion
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/QrScanInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/QrScanInteractorTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.domain.interactor
+
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
+import eudiverifier.verifierapp.generated.resources.Res
+import eudiverifier.verifierapp.generated.resources.qr_scan_screen_error_invalid_code
+import eudiverifier.verifierapp.generated.resources.qr_scan_screen_error_missing_documents
+import eudiverifier.verifierapp.generated.resources.qr_scan_screen_title
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class QrScanInteractorTest {
+
+    /**
+     * Builds the SUT, [QrScanInteractorImpl], with a dispatcher that shares the `runTest`
+     * scheduler and a Mokkery mock for the [ResourceProvider].
+     */
+    private fun TestScope.createInteractor(
+        resourceProvider: ResourceProvider = stringResourceProvider()
+    ): QrScanInteractor {
+        val dispatcher = coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
+        return QrScanInteractorImpl(
+            resourceProvider = resourceProvider,
+            dispatcher = dispatcher
+        )
+    }
+
+    //region getScreenTitle
+
+    @Test
+    fun `getScreenTitle returns localized title`() = runTest(StandardTestDispatcher()) {
+        val interactor = createInteractor()
+
+        assertEquals("QR scan title", interactor.getScreenTitle())
+    }
+
+    //endregion
+
+    //region qrCodeIsValid
+
+    @Test
+    fun `qrCodeIsValid returns true for mdoc prefix`() = runTest(StandardTestDispatcher()) {
+        val interactor = createInteractor()
+
+        assertTrue(interactor.qrCodeIsValid("mdoc:abc123"))
+    }
+
+    @Test
+    fun `qrCodeIsValid is case insensitive for the prefix`() = runTest(StandardTestDispatcher()) {
+        val interactor = createInteractor()
+
+        assertTrue(interactor.qrCodeIsValid("MDOC:abc123"))
+    }
+
+    @Test
+    fun `qrCodeIsValid returns false for a non-mdoc prefix`() = runTest(StandardTestDispatcher()) {
+        val interactor = createInteractor()
+
+        assertFalse(interactor.qrCodeIsValid("https://example.com"))
+    }
+
+    @Test
+    fun `qrCodeIsValid returns false for an empty string`() = runTest(StandardTestDispatcher()) {
+        val interactor = createInteractor()
+
+        assertFalse(interactor.qrCodeIsValid(""))
+    }
+
+    //endregion
+
+    //region messages
+
+    @Test
+    fun `getInvalidQrCodeMessage returns localized message`() = runTest(StandardTestDispatcher()) {
+        val interactor = createInteractor()
+
+        assertEquals("Invalid QR code", interactor.getInvalidQrCodeMessage())
+    }
+
+    @Test
+    fun `getMissingDocumentsMessage returns localized message`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor()
+
+            assertEquals("Missing documents", interactor.getMissingDocumentsMessage())
+        }
+
+    //endregion
+
+    //region Mocks
+
+    private fun stringResourceProvider(): ResourceProvider = mock {
+        every { getSharedString(Res.string.qr_scan_screen_title) } returns "QR scan title"
+        every { getSharedString(Res.string.qr_scan_screen_error_invalid_code) } returns "Invalid QR code"
+        every {
+            getSharedString(Res.string.qr_scan_screen_error_missing_documents)
+        } returns "Missing documents"
+    }
+
+    //endregion
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/SettingsInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/SettingsInteractorTest.kt
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.domain.interactor
+
+import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import eu.europa.ec.euidi.verifier.core.controller.DataStoreController
+import eu.europa.ec.euidi.verifier.core.controller.PrefKey
+import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
+import eu.europa.ec.euidi.verifier.core.provider.UuidProvider
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemTrailingContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.ui.settings.model.SettingsItemUi
+import eu.europa.ec.euidi.verifier.presentation.ui.settings.model.SettingsTypeUi
+import eudiverifier.verifierapp.generated.resources.Res
+import eudiverifier.verifierapp.generated.resources.settings_screen_category_data_retrieval_methods_description
+import eudiverifier.verifierapp.generated.resources.settings_screen_category_data_retrieval_methods_title
+import eudiverifier.verifierapp.generated.resources.settings_screen_category_data_retrieval_options_title
+import eudiverifier.verifierapp.generated.resources.settings_screen_category_general_title
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_ble_central_client_description_selected
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_ble_central_client_description_unselected
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_ble_central_client_title
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_ble_peripheral_server_description_selected
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_ble_peripheral_server_description_unselected
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_ble_peripheral_server_title
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_clear_ble_description_selected
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_clear_ble_description_unselected
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_clear_ble_title
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_retain_data_description_selected
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_retain_data_description_unselected
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_retain_data_title
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_use_l2cap_description_selected
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_use_l2cap_description_unselected
+import eudiverifier.verifierapp.generated.resources.settings_screen_item_use_l2cap_title
+import eudiverifier.verifierapp.generated.resources.settings_screen_title
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.compose.resources.StringResource
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SettingsInteractorTest {
+
+    /**
+     * Builds the SUT, [SettingsInteractorImpl], with a dispatcher that shares the `runTest`
+     * scheduler. The [DataStoreController] is built by the caller so its [putBoolean] writes can
+     * be verified.
+     */
+    private fun TestScope.createInteractor(
+        uuidProvider: UuidProvider = sequentialUuidProvider(),
+        resourceProvider: ResourceProvider = stringResourceProvider(),
+        dataStoreController: DataStoreController = dataStore(),
+    ): SettingsInteractor {
+        val dispatcher = coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
+        return SettingsInteractorImpl(
+            uuidProvider = uuidProvider,
+            resourceProvider = resourceProvider,
+            dataStoreController = dataStoreController,
+            dispatcher = dispatcher
+        )
+    }
+
+    //region getScreenTitle
+
+    @Test
+    fun `getScreenTitle returns localized title`() = runTest(StandardTestDispatcher()) {
+        val interactor = createInteractor()
+
+        assertEquals("Settings title", interactor.getScreenTitle())
+    }
+
+    //endregion
+
+    //region getSettingsItemsUi
+
+    @Test
+    fun `getSettingsItemsUi builds three sections with defaults`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor(dataStoreController = dataStore())
+
+            val items = interactor.getSettingsItemsUi()
+
+            // 3 category headers + (1 general + 2 retrieval options + 2 retrieval methods) items.
+            assertEquals(8, items.size)
+
+            // General section
+            val generalHeader = items[0] as SettingsItemUi.CategoryHeader
+            assertEquals("General", generalHeader.title)
+            assertNull(generalHeader.description)
+
+            val retainItem = items[1] as SettingsItemUi.CategoryItem
+            assertEquals(SettingsTypeUi.RetainData, retainItem.type)
+            assertEquals("uuid-0", retainItem.data.itemId)
+            assertEquals(
+                "Retain data",
+                (retainItem.data.mainContentData as ListItemMainContentDataUi.Text).text
+            )
+            // No stored value and not a retrieval method -> defaults to unchecked.
+            assertFalse(
+                (retainItem.data.trailingContentData as ListItemTrailingContentDataUi.Switch)
+                    .switchData.isChecked
+            )
+            assertEquals("Retain data OFF", retainItem.data.supportingText)
+            assertTrue(retainItem.isLastInSection)
+
+            // Retrieval options section
+            val optionsHeader = items[2] as SettingsItemUi.CategoryHeader
+            assertEquals("Retrieval options", optionsHeader.title)
+            assertNull(optionsHeader.description)
+
+            val useL2CapItem = items[3] as SettingsItemUi.CategoryItem
+            assertEquals(SettingsTypeUi.UseL2Cap, useL2CapItem.type)
+            assertFalse(useL2CapItem.isLastInSection)
+
+            val clearBleItem = items[4] as SettingsItemUi.CategoryItem
+            assertEquals(SettingsTypeUi.ClearBleCache, clearBleItem.type)
+            assertTrue(clearBleItem.isLastInSection)
+
+            // Retrieval methods section (carries a header description)
+            val methodsHeader = items[5] as SettingsItemUi.CategoryHeader
+            assertEquals("Retrieval methods", methodsHeader.title)
+            assertEquals("Retrieval methods description", methodsHeader.description)
+
+            val centralItem = items[6] as SettingsItemUi.CategoryItem
+            assertEquals(SettingsTypeUi.BleCentralClient, centralItem.type)
+            // Retrieval methods default to checked.
+            assertTrue(
+                (centralItem.data.trailingContentData as ListItemTrailingContentDataUi.Switch)
+                    .switchData.isChecked
+            )
+            assertEquals("BLE central ON", centralItem.data.supportingText)
+            assertFalse(centralItem.isLastInSection)
+
+            val peripheralItem = items[7] as SettingsItemUi.CategoryItem
+            assertEquals(SettingsTypeUi.BlePeripheralServer, peripheralItem.type)
+            assertTrue(peripheralItem.isLastInSection)
+        }
+
+    @Test
+    fun `getSettingsItemsUi reflects stored values and selected descriptions`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor(
+                dataStoreController = dataStore(
+                    stored = mapOf(
+                        PrefKey.RETAIN_DATA to true,
+                        PrefKey.BLE_CENTRAL_CLIENT to false,
+                    )
+                )
+            )
+
+            val items = interactor.getSettingsItemsUi()
+
+            val retainItem = items[1] as SettingsItemUi.CategoryItem
+            assertTrue(
+                (retainItem.data.trailingContentData as ListItemTrailingContentDataUi.Switch)
+                    .switchData.isChecked
+            )
+            assertEquals("Retain data ON", retainItem.data.supportingText)
+
+            val centralItem = items[6] as SettingsItemUi.CategoryItem
+            // Stored false overrides the retrieval-method default of true.
+            assertFalse(
+                (centralItem.data.trailingContentData as ListItemTrailingContentDataUi.Switch)
+                    .switchData.isChecked
+            )
+            assertEquals("BLE central OFF", centralItem.data.supportingText)
+        }
+
+    //endregion
+
+    //region togglePrefBoolean
+
+    @Test
+    fun `togglePrefBoolean toggles a general preference`() = runTest(StandardTestDispatcher()) {
+        val dataStoreController = dataStore()
+        val interactor = createInteractor(dataStoreController = dataStoreController)
+
+        interactor.togglePrefBoolean(PrefKey.RETAIN_DATA)
+
+        verifySuspend(exactly(1)) { dataStoreController.putBoolean(PrefKey.RETAIN_DATA, true) }
+    }
+
+    @Test
+    fun `togglePrefBoolean enabling a retrieval method stores the new value`() =
+        runTest(StandardTestDispatcher()) {
+            val dataStoreController = dataStore(
+                stored = mapOf(PrefKey.BLE_CENTRAL_CLIENT to false)
+            )
+            val interactor = createInteractor(dataStoreController = dataStoreController)
+
+            interactor.togglePrefBoolean(PrefKey.BLE_CENTRAL_CLIENT)
+
+            verifySuspend(exactly(1)) {
+                dataStoreController.putBoolean(PrefKey.BLE_CENTRAL_CLIENT, true)
+            }
+        }
+
+    @Test
+    fun `togglePrefBoolean keeps the last active retrieval method enabled`() =
+        runTest(StandardTestDispatcher()) {
+            val dataStoreController = dataStore(
+                stored = mapOf(
+                    PrefKey.BLE_CENTRAL_CLIENT to true,
+                    PrefKey.BLE_PERIPHERAL_SERVER to false,
+                )
+            )
+            val interactor = createInteractor(dataStoreController = dataStoreController)
+
+            // Attempting to disable the only active retrieval method must be a no-op.
+            interactor.togglePrefBoolean(PrefKey.BLE_CENTRAL_CLIENT)
+
+            verifySuspend(exactly(0)) { dataStoreController.putBoolean(any(), any()) }
+        }
+
+    @Test
+    fun `togglePrefBoolean disables a retrieval method when another stays active`() =
+        runTest(StandardTestDispatcher()) {
+            val dataStoreController = dataStore(
+                stored = mapOf(
+                    PrefKey.BLE_CENTRAL_CLIENT to true,
+                    PrefKey.BLE_PERIPHERAL_SERVER to true,
+                )
+            )
+            val interactor = createInteractor(dataStoreController = dataStoreController)
+
+            interactor.togglePrefBoolean(PrefKey.BLE_CENTRAL_CLIENT)
+
+            verifySuspend(exactly(1)) {
+                dataStoreController.putBoolean(PrefKey.BLE_CENTRAL_CLIENT, false)
+            }
+        }
+
+    //endregion
+
+    //region Mocks
+
+    private fun sequentialUuidProvider(): UuidProvider {
+        var counter = 0
+        return mock {
+            every { provideUuid() } calls { "uuid-${counter++}" }
+        }
+    }
+
+    /**
+     * Mocks the [DataStoreController]. The three pref-grouping lists mirror production so the
+     * interactor classifies keys the same way. `getBoolean` returns the stored value or falls back
+     * to the supplied default (matching the real implementation), and `putBoolean` is left to the
+     * `autoUnit` mode so the writes can be verified per test.
+     */
+    private fun dataStore(stored: Map<PrefKey, Boolean> = emptyMap()): DataStoreController {
+        val dataStore = mock<DataStoreController>(MockMode.autoUnit)
+        every { dataStore.getGeneralPrefs() } returns listOf(PrefKey.RETAIN_DATA)
+        every {
+            dataStore.getRetrievalOptionsPrefs()
+        } returns listOf(PrefKey.USE_L2CAP, PrefKey.CLEAR_BLE_CACHE)
+        every {
+            dataStore.getRetrievalMethodPrefs()
+        } returns listOf(PrefKey.BLE_CENTRAL_CLIENT, PrefKey.BLE_PERIPHERAL_SERVER)
+        everySuspend {
+            dataStore.getBoolean(
+                any(),
+                any()
+            )
+        } calls { (key: PrefKey, default: Boolean?) ->
+            stored[key] ?: default
+        }
+        return dataStore
+    }
+
+    private fun stringResourceProvider(): ResourceProvider {
+        val resourceProvider = mock<ResourceProvider>()
+        every { resourceProvider.getSharedString(any()) } calls { (resource: StringResource) ->
+            when (resource) {
+                Res.string.settings_screen_title -> "Settings title"
+
+                Res.string.settings_screen_category_general_title -> "General"
+                Res.string.settings_screen_category_data_retrieval_options_title -> "Retrieval options"
+                Res.string.settings_screen_category_data_retrieval_methods_title -> "Retrieval methods"
+                Res.string.settings_screen_category_data_retrieval_methods_description -> "Retrieval methods description"
+
+                Res.string.settings_screen_item_retain_data_title -> "Retain data"
+                Res.string.settings_screen_item_retain_data_description_selected -> "Retain data ON"
+                Res.string.settings_screen_item_retain_data_description_unselected -> "Retain data OFF"
+
+                Res.string.settings_screen_item_use_l2cap_title -> "Use L2CAP"
+                Res.string.settings_screen_item_use_l2cap_description_selected -> "L2CAP ON"
+                Res.string.settings_screen_item_use_l2cap_description_unselected -> "L2CAP OFF"
+
+                Res.string.settings_screen_item_clear_ble_title -> "Clear BLE cache"
+                Res.string.settings_screen_item_clear_ble_description_selected -> "Clear BLE ON"
+                Res.string.settings_screen_item_clear_ble_description_unselected -> "Clear BLE OFF"
+
+                Res.string.settings_screen_item_ble_central_client_title -> "BLE central"
+                Res.string.settings_screen_item_ble_central_client_description_selected -> "BLE central ON"
+                Res.string.settings_screen_item_ble_central_client_description_unselected -> "BLE central OFF"
+
+                Res.string.settings_screen_item_ble_peripheral_server_title -> "BLE peripheral"
+                Res.string.settings_screen_item_ble_peripheral_server_description_selected -> "BLE peripheral ON"
+                Res.string.settings_screen_item_ble_peripheral_server_description_unselected -> "BLE peripheral OFF"
+
+                else -> "STR"
+            }
+        }
+        return resourceProvider
+    }
+
+    //endregion
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/ShowDocumentsInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/ShowDocumentsInteractorTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.domain.interactor
+
+import dev.mokkery.answering.calls
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
+import eu.europa.ec.euidi.verifier.core.provider.UuidProvider
+import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType
+import eu.europa.ec.euidi.verifier.domain.config.model.ClaimItem
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.model.ReceivedDocumentUi
+import eu.europa.ec.euidi.verifier.presentation.ui.show_document.model.DocumentValidityUi
+import eudiverifier.verifierapp.generated.resources.Res
+import eudiverifier.verifierapp.generated.resources.document_type_pid
+import eudiverifier.verifierapp.generated.resources.show_documents_screen_title
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.compose.resources.StringResource
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ShowDocumentsInteractorTest {
+
+    /**
+     * Builds the SUT, [ShowDocumentsInteractorImpl], with a dispatcher that shares the `runTest`
+     * scheduler and Mokkery mocks for its collaborators.
+     */
+    private fun TestScope.createInteractor(
+        resourceProvider: ResourceProvider = stringResourceProvider(),
+        uuidProvider: UuidProvider = sequentialUuidProvider(),
+    ): ShowDocumentsInteractor {
+        val dispatcher = coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
+        return ShowDocumentsInteractorImpl(
+            resourceProvider = resourceProvider,
+            uuidProvider = uuidProvider,
+            dispatcher = dispatcher
+        )
+    }
+
+    //region getScreenTitle
+
+    @Test
+    fun `getScreenTitle returns localized title`() = runTest(StandardTestDispatcher()) {
+        val interactor = createInteractor()
+
+        assertEquals("Show documents title", interactor.getScreenTitle())
+    }
+
+    //endregion
+
+    //region transformToUiItems
+
+    @Test
+    fun `transformToUiItems returns empty list for empty input`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor()
+
+            assertTrue(interactor.transformToUiItems(emptyList()).isEmpty())
+        }
+
+    @Test
+    fun `transformToUiItems maps a received document to a DocumentUi`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor()
+
+            val document = ReceivedDocumentUi(
+                id = "doc-1",
+                documentType = AttestationType.Pid,
+                claims = mapOf(ClaimItem("given_name") to "John"),
+                documentValidity = DocumentValidityUi(
+                    isDeviceSignatureValid = true,
+                    isIssuerSignatureValid = false,
+                    isDataIntegrityIntact = true,
+                    signed = "2025-01-01",
+                    validFrom = "2025-01-02",
+                    validUntil = "2025-12-31",
+                )
+            )
+
+            val result = interactor.transformToUiItems(listOf(document))
+
+            assertEquals(1, result.size)
+            val documentUi = result.single()
+
+            assertEquals("doc-1", documentUi.id)
+            assertEquals(AttestationType.Pid.docType, documentUi.docType)
+
+            // One UI claim per claim entry, with an id provided by the uuid provider.
+            assertEquals(1, documentUi.uiClaims.size)
+            assertEquals("uuid-0", documentUi.uiClaims.single().itemId)
+            val claimMain = documentUi.uiClaims.single().mainContentData
+            assertTrue(claimMain is ListItemMainContentDataUi.Text)
+            assertEquals("John", claimMain.text)
+
+            // 3 boolean validity items + 3 non-null string validity items.
+            assertEquals(6, documentUi.validityInfo.size)
+        }
+
+    //endregion
+
+    //region Mocks
+
+    private fun sequentialUuidProvider(): UuidProvider {
+        var counter = 0
+        return mock {
+            every { provideUuid() } calls { "uuid-${counter++}" }
+        }
+    }
+
+    /**
+     * The interactor resolves claim translations dynamically via `UiTransformer.getClaimTranslation`,
+     * which may request arbitrary string resources. A `calls`-based answer maps the resources we
+     * assert on and returns a non-empty fallback for the rest.
+     */
+    private fun stringResourceProvider(): ResourceProvider = mock {
+        every { getSharedString(any()) } calls { (resource: StringResource) ->
+            when (resource) {
+                Res.string.show_documents_screen_title -> "Show documents title"
+                Res.string.document_type_pid -> "PID"
+                else -> "translated"
+            }
+        }
+    }
+
+    //endregion
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/TransferStatusInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/TransferStatusInteractorTest.kt
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.domain.interactor
+
+import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import eu.europa.ec.euidi.verifier.core.controller.DataStoreController
+import eu.europa.ec.euidi.verifier.core.controller.PrefKey
+import eu.europa.ec.euidi.verifier.core.controller.TransferController
+import eu.europa.ec.euidi.verifier.core.controller.TransferStatus
+import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
+import eu.europa.ec.euidi.verifier.core.provider.UuidProvider
+import eu.europa.ec.euidi.verifier.domain.config.ConfigProvider
+import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType
+import eu.europa.ec.euidi.verifier.domain.config.model.ClaimItem
+import eu.europa.ec.euidi.verifier.domain.config.model.DocumentMode
+import eu.europa.ec.euidi.verifier.domain.config.model.Logger
+import eu.europa.ec.euidi.verifier.domain.model.DocumentValidityDomain
+import eu.europa.ec.euidi.verifier.domain.model.ReceivedDocumentDomain
+import eu.europa.ec.euidi.verifier.presentation.model.RequestedDocumentUi
+import eu.europa.ec.euidi.verifier.presentation.ui.show_document.model.DocumentValidityUi
+import eudiverifier.verifierapp.generated.resources.Res
+import eudiverifier.verifierapp.generated.resources.document_type_employee_id
+import eudiverifier.verifierapp.generated.resources.document_type_mdl
+import eudiverifier.verifierapp.generated.resources.document_type_pid
+import eudiverifier.verifierapp.generated.resources.transfer_status_screen_request_label
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+class TransferStatusInteractorTest {
+
+    /**
+     * Builds the SUT, [TransferStatusInteractorImpl], with a dispatcher that shares the `runTest`
+     * scheduler and Mokkery mocks for its collaborators. Tests that verify interactions create the
+     * relevant mock explicitly and pass it in.
+     */
+    private fun TestScope.createInteractor(
+        resourceProvider: ResourceProvider = stringResourceProvider(),
+        uuidProvider: UuidProvider = sequentialUuidProvider(),
+        transferController: TransferController = transferController(),
+        dataStoreController: DataStoreController = dataStore(),
+        configProvider: ConfigProvider = configProvider(),
+    ): TransferStatusInteractor {
+        val dispatcher = coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
+        return TransferStatusInteractorImpl(
+            resourceProvider = resourceProvider,
+            uuidProvider = uuidProvider,
+            transferController = transferController,
+            dataStoreController = dataStoreController,
+            configProvider = configProvider,
+            dispatcher = dispatcher
+        )
+    }
+
+    //region transformToReceivedDocumentsUi
+
+    @Test
+    fun `transformToReceivedDocumentsUi maps domain documents to ui models`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor()
+
+            val received = listOf(
+                ReceivedDocumentDomain(
+                    isTrusted = true,
+                    docType = AttestationType.Pid.docType,
+                    claims = mapOf(ClaimItem("given_name") to "John"),
+                    validity = DocumentValidityDomain(
+                        isDeviceSignatureValid = true,
+                        isIssuerSignatureValid = true,
+                        isDataIntegrityIntact = true,
+                        signed = null,
+                        validFrom = null,
+                        validUntil = null,
+                    )
+                )
+            )
+
+            val result = interactor.transformToReceivedDocumentsUi(
+                requestedDocuments = emptyList(),
+                receivedDocuments = received
+            )
+
+            assertEquals(1, result.size)
+            val doc = result.single()
+            assertEquals("uuid-0", doc.id)
+            assertEquals(AttestationType.Pid, doc.documentType)
+            assertEquals(mapOf(ClaimItem("given_name") to "John"), doc.claims)
+            assertEquals(
+                DocumentValidityUi(
+                    isDeviceSignatureValid = true,
+                    isIssuerSignatureValid = true,
+                    isDataIntegrityIntact = true,
+                    signed = null,
+                    validFrom = null,
+                    validUntil = null,
+                ),
+                doc.documentValidity
+            )
+        }
+
+    @Test
+    fun `transformToReceivedDocumentsUi returns empty list for empty input`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor()
+
+            val result = interactor.transformToReceivedDocumentsUi(
+                requestedDocuments = emptyList(),
+                receivedDocuments = emptyList()
+            )
+
+            assertTrue(result.isEmpty())
+        }
+
+    //endregion
+
+    //region prepareConnection
+
+    @Test
+    fun `prepareConnection initializes verifier and transfer manager with stored settings`() =
+        runTest(StandardTestDispatcher()) {
+            val transferController = transferController()
+            val interactor = createInteractor(
+                transferController = transferController,
+                dataStoreController = dataStore(
+                    stored = mapOf(
+                        PrefKey.BLE_CENTRAL_CLIENT to false,
+                        PrefKey.BLE_PERIPHERAL_SERVER to true,
+                        PrefKey.USE_L2CAP to true,
+                        PrefKey.CLEAR_BLE_CACHE to true,
+                    )
+                ),
+                configProvider = configProvider(
+                    certificates = listOf("CERT_A", "CERT_B"),
+                    logger = Logger.LEVEL_DEBUG
+                )
+            )
+
+            interactor.prepareConnection()
+
+            verify(exactly(1)) {
+                transferController.initializeVerifier(
+                    listOf("CERT_A", "CERT_B"),
+                    Logger.LEVEL_DEBUG
+                )
+            }
+            verify(exactly(1)) {
+                transferController.initializeTransferManager(
+                    bleCentralClientMode = false,
+                    blePeripheralServerMode = true,
+                    useL2Cap = true,
+                    clearBleCache = true
+                )
+            }
+        }
+
+    @Test
+    fun `prepareConnection uses defaults when settings are not stored`() =
+        runTest(StandardTestDispatcher()) {
+            val transferController = transferController()
+            val interactor = createInteractor(
+                transferController = transferController,
+                dataStoreController = dataStore()
+            )
+
+            interactor.prepareConnection()
+
+            // Defaults baked into the interactor (BLE modes on, L2CAP/clear-cache off).
+            verify(exactly(1)) {
+                transferController.initializeTransferManager(
+                    bleCentralClientMode = true,
+                    blePeripheralServerMode = true,
+                    useL2Cap = false,
+                    clearBleCache = false
+                )
+            }
+        }
+
+    //endregion
+
+    //region startEngagement
+
+    @Test
+    fun `startEngagement delegates the qr code to the transfer controller`() =
+        runTest(StandardTestDispatcher()) {
+            val transferController = transferController()
+            val interactor = createInteractor(transferController = transferController)
+
+            interactor.startEngagement("mdoc:engagement")
+
+            verify(exactly(1)) { transferController.startEngagement("mdoc:engagement") }
+        }
+
+    //endregion
+
+    //region getConnectionStatus
+
+    @Test
+    fun `getConnectionStatus sends the request with retainData from settings`() =
+        runTest(StandardTestDispatcher()) {
+            val transferController =
+                transferController(statusFlow = flowOf(TransferStatus.RequestSent))
+            val interactor = createInteractor(
+                transferController = transferController,
+                dataStoreController = dataStore(stored = mapOf(PrefKey.RETAIN_DATA to true))
+            )
+
+            val docs = listOf(
+                RequestedDocumentUi(
+                    id = "PID_DOC",
+                    documentType = AttestationType.Pid,
+                    mode = DocumentMode.FULL,
+                )
+            )
+
+            val status = interactor.getConnectionStatus(docs).first()
+
+            assertEquals(TransferStatus.RequestSent, status)
+            verify(exactly(1)) { transferController.sendRequest(docs, true) }
+        }
+
+    //endregion
+
+    //region getRequestData
+
+    @Test
+    fun `getRequestData prefixes the label and joins document types`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor()
+
+            val docs = listOf(
+                RequestedDocumentUi(
+                    id = "PID_DOC",
+                    documentType = AttestationType.Pid,
+                    mode = DocumentMode.FULL,
+                ),
+                RequestedDocumentUi(
+                    id = "MDL_DOC",
+                    documentType = AttestationType.Mdl,
+                    mode = DocumentMode.CUSTOM,
+                )
+            )
+
+            val result = interactor.getRequestData(docs)
+
+            assertEquals("Requesting: Full PID; Custom MDL", result)
+        }
+
+    @Test
+    fun `getRequestData returns just the label when there are no documents`() =
+        runTest(StandardTestDispatcher()) {
+            val interactor = createInteractor()
+
+            val result = interactor.getRequestData(emptyList())
+
+            assertEquals("Requesting: ", result)
+        }
+
+    //endregion
+
+    //region stopConnection
+
+    @Test
+    fun `stopConnection delegates to the transfer controller`() =
+        runTest(StandardTestDispatcher()) {
+            val transferController = transferController()
+            val interactor = createInteractor(transferController = transferController)
+
+            interactor.stopConnection()
+
+            verify(exactly(1)) { transferController.stopConnection() }
+        }
+
+    //endregion
+
+    //region Mocks
+
+    private fun sequentialUuidProvider(): UuidProvider {
+        var counter = 0
+        return mock {
+            every { provideUuid() } calls { "uuid-${counter++}" }
+        }
+    }
+
+    private fun transferController(
+        statusFlow: Flow<TransferStatus> = flowOf(TransferStatus.Connected)
+    ): TransferController {
+        // autoUnit backs the Unit-returning delegations; sendRequest needs an explicit answer.
+        val transferController = mock<TransferController>(MockMode.autoUnit)
+        every { transferController.sendRequest(any(), any()) } returns statusFlow
+        return transferController
+    }
+
+    /**
+     * Returns the raw stored value (null when absent) and ignores the supplied default on purpose,
+     * so the interactor's own `?: default` fallback in getSettingsValue is exercised for missing keys.
+     */
+    private fun dataStore(stored: Map<PrefKey, Boolean> = emptyMap()): DataStoreController {
+        val dataStore = mock<DataStoreController>()
+        everySuspend { dataStore.getBoolean(any(), any()) } calls { (key: PrefKey, _: Boolean?) ->
+            stored[key]
+        }
+        return dataStore
+    }
+
+    private fun configProvider(
+        certificates: List<String> = listOf("CERT"),
+        logger: Logger = Logger.LEVEL_DEBUG,
+    ): ConfigProvider {
+        val configProvider = mock<ConfigProvider>()
+        everySuspend { configProvider.getCertificates() } returns certificates
+        every { configProvider.logger } returns logger
+        return configProvider
+    }
+
+    private fun stringResourceProvider(): ResourceProvider {
+        val resourceProvider = mock<ResourceProvider>()
+        every {
+            resourceProvider.getSharedString(Res.string.transfer_status_screen_request_label)
+        } returns "Requesting:"
+        every { resourceProvider.getSharedString(Res.string.document_type_pid) } returns "PID"
+        every { resourceProvider.getSharedString(Res.string.document_type_mdl) } returns "MDL"
+        every {
+            resourceProvider.getSharedString(Res.string.document_type_employee_id)
+        } returns "Employee ID"
+        return resourceProvider
+    }
+
+    //endregion
+}


### PR DESCRIPTION
- Add Mokkery plugin and dependency (v3.3.0).
- Downgrade Kotlin to 2.3.20 and upgrade KSP to 2.3.9 to ensure compatibility with Mokkery.
- Add comprehensive unit tests for `TransferStatusInteractor`, `SettingsInteractor`, `QrScanInteractor`, `MenuInteractor`, and `ShowDocumentsInteractor`.
- Migrate `HomeInteractorTest`, `DocumentsToRequestInteractorTest`, and `CustomRequestInteractorTest` from manual fakes to Mokkery mocks.
- Simplify checkbox filtering logic in `CustomRequestInteractor`.
- Refactor `SettingsInteractor` to use `Map.getValue()` for preference lookups and remove redundant default parameters.
- Refine document selection logic in `DocumentsToRequestInteractor` to better handle switching between full and custom modes.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [x] Added Tests ()

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
