### PR TITLE
Expand unit test coverage and refactor test utilities

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "2.3.20"
 mokkery = "3.3.0"
+turbine = "1.2.1"
 kotlinxCoroutinesTest = "1.11.0"
 ksp = "2.3.9"
 agp = "9.2.1"
@@ -26,6 +27,7 @@ composeMaterial3 = "1.10.0-alpha05"
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 

--- a/verifierApp/build.gradle.kts
+++ b/verifierApp/build.gradle.kts
@@ -118,6 +118,7 @@ kotlin {
             implementation(libs.kotlin.test)
             implementation(libs.koin.test)
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.turbine)
         }
     }
 
@@ -144,9 +145,42 @@ kover {
             xml { onCheck = false }
             filters {
                 excludes {
+
+                    annotatedBy("androidx.compose.runtime.Composable")
+                    annotatedBy("kotlinx.parcelize.Parcelize")
+
                     classes(
                         "*BuildConfig*",
                         "org.koin*",
+                        "*ScreenKt*",
+                        "*RouterKt*",
+                        "*ComposableSingletons*",
+                        "*ConfigProviderImpl*",
+                        "*ByteArrayExtensionsKt*",
+                        "*PermissionsControllerExtensionsKt*",
+                        "*Constants",
+                        "*AndroidPlatformController*",
+                        "*AndroidTransferController*",
+                        "*RuntimeProvider*",
+                        "*ContainerActivity*",
+                        "*DocumentKeyValueUiParser*",
+                        "*ToastManager*",
+                        "*DocumentClaimsKt*",
+                    )
+
+                    packages(
+                        "eu.europa.ec.euidi.verifier.core.di",
+                        "eu.europa.ec.euidi.verifier.domain.di",
+                        "eu.europa.ec.euidi.verifier.presentation.di",
+                        "eu.europa.ec.euidi.verifier.core.controller.model",
+                        "eu.europa.ec.euidi.verifier.core.provider",
+                        "eu.europa.ec.euidi.verifier.presentation.theme",
+                        "eu.europa.ec.euidi.verifier.presentation.navigation",
+                        "eu.europa.ec.euidi.verifier.presentation.component",
+                        "eu.europa.ec.euidi.verifier.presentation.utils",
+                        "eu.europa.ec.euidi.verifier.presentation.model",
+                        "eu.europa.ec.euidi.verifier.presentation.ui.container",
+                        "eudiverifier.verifierapp.generated",
                     )
                 }
             }

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/core/extension/Base64Extensions.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/core/extension/Base64Extensions.kt
@@ -47,7 +47,7 @@ fun String.decodeBase64ToBytesOrNull(): ByteArray? {
         if (isUrlSafe) {
             Base64.UrlSafe.decode(source = padded)
         } else {
-            Base64.Default.decode(source = padded)
+            Base64.decode(source = padded)
         }
     }.getOrNull()
 }

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/transformer/UiTransformer.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/domain/transformer/UiTransformer.kt
@@ -127,9 +127,12 @@ object UiTransformer {
         val allStringResources: Map<String, StringResource> = Res.allStringResources
         val resourceKey = "${attestationType.replace(" ", "_")}_${claimLabel}".lowercase()
 
-        return allStringResources[resourceKey]?.let {
-            resourceProvider.getSharedString(it)
-        } ?: claimLabel
+        val resource = allStringResources[resourceKey]
+        return if (resource != null) {
+            resourceProvider.getSharedString(resource)
+        } else {
+            claimLabel
+        }
     }
 
     fun keyIsPortrait(key: String): Boolean {

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/doc_to_request/DocumentsToRequestViewModel.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/doc_to_request/DocumentsToRequestViewModel.kt
@@ -156,13 +156,7 @@ class DocumentsToRequestViewModel(
         }
     }
 
-    private fun checkEnableDoneButton(
-        requestedDocs: List<RequestedDocumentUi> = uiState.value.requestedDocuments
-    ) {
-        requestedDocs.any {
-            it.id in uiState.value.filteredDocuments.map { doc -> doc.id }
-        }
-
+    private fun checkEnableDoneButton(requestedDocs: List<RequestedDocumentUi>) {
         setState {
             copy(isButtonEnabled = requestedDocs.isNotEmpty())
         }

--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/home/HomeViewModel.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/home/HomeViewModel.kt
@@ -128,7 +128,7 @@ class HomeViewModel(
     private fun initiate(docs: List<RequestedDocumentUi>?) {
         viewModelScope.launch {
 
-            uiState.value.mainButtonData ?: run {
+            val baseButtonData = uiState.value.mainButtonData ?: run {
                 val title = interactor.getScreenTitle()
                 val buttonData = interactor.getDefaultMainButtonData()
                 setState {
@@ -138,16 +138,17 @@ class HomeViewModel(
                         isLoading = false
                     )
                 }
+                buttonData
             }
 
-            handleDocs(docs = docs)
+            handleDocs(docs = docs, baseButtonData = baseButtonData)
         }
     }
 
-    private suspend fun handleDocs(docs: List<RequestedDocumentUi>?) {
-
-        val baseButtonData = uiState.value.mainButtonData ?: return
-
+    private suspend fun handleDocs(
+        docs: List<RequestedDocumentUi>?,
+        baseButtonData: ListItemDataUi,
+    ) {
         if (!docs.isNullOrEmpty()) {
             val updatedButton = interactor.formatMainButtonData(
                 requestedDocs = docs,

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/core/controller/DataStoreControllerTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/core/controller/DataStoreControllerTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.core.controller
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalUuidApi::class)
+class DataStoreControllerTest {
+
+    // A real Preferences DataStore backed by a unique temp file per controller, so tests are isolated.
+    private fun controller(): DataStoreController {
+        val path = "build/test-datastore/${Uuid.random()}.preferences_pb"
+        return DataStoreControllerImpl(DataStoreControllerImpl.createDataStore { path })
+    }
+
+    @Test
+    fun `boolean is stored and read back, falling back to the default when absent`() = runTest {
+        val controller = controller()
+
+        controller.putBoolean(PrefKey.RETAIN_DATA, true)
+
+        assertEquals(true, controller.getBoolean(PrefKey.RETAIN_DATA))
+        assertEquals(false, controller.getBoolean(PrefKey.USE_L2CAP, default = false))
+        assertNull(controller.getBoolean(PrefKey.CLEAR_BLE_CACHE))
+    }
+
+    @Test
+    fun `int is stored and read back, with a default fallback`() = runTest {
+        val controller = controller()
+
+        controller.putInt(PrefKey.RETAIN_DATA, 42)
+
+        assertEquals(42, controller.getInt(PrefKey.RETAIN_DATA))
+        assertEquals(7, controller.getInt(PrefKey.USE_L2CAP, default = 7))
+    }
+
+    @Test
+    fun `string is stored and read back`() = runTest {
+        val controller = controller()
+
+        controller.putString(PrefKey.RETAIN_DATA, "hello")
+
+        assertEquals("hello", controller.getString(PrefKey.RETAIN_DATA))
+    }
+
+    @Test
+    fun `double is stored and read back`() = runTest {
+        val controller = controller()
+
+        controller.putDouble(PrefKey.RETAIN_DATA, 1.5)
+
+        assertEquals(1.5, controller.getDouble(PrefKey.RETAIN_DATA))
+    }
+
+    @Test
+    fun `float is stored and read back`() = runTest {
+        val controller = controller()
+
+        controller.putFloat(PrefKey.RETAIN_DATA, 2.5f)
+
+        assertEquals(2.5f, controller.getFloat(PrefKey.RETAIN_DATA))
+    }
+
+    @Test
+    fun `long is stored and read back`() = runTest {
+        val controller = controller()
+
+        controller.putLong(PrefKey.RETAIN_DATA, 99L)
+
+        assertEquals(99L, controller.getLong(PrefKey.RETAIN_DATA))
+    }
+
+    @Test
+    fun `byteArray is stored and read back`() = runTest {
+        val controller = controller()
+        val bytes = byteArrayOf(1, 2, 3)
+
+        controller.putByteArray(PrefKey.RETAIN_DATA, bytes)
+
+        assertContentEquals(bytes, controller.getByteArray(PrefKey.RETAIN_DATA))
+    }
+
+    @Test
+    fun `preference grouping lists expose the configured keys`() {
+        val controller = controller()
+
+        assertEquals(listOf(PrefKey.RETAIN_DATA), controller.getGeneralPrefs())
+        assertEquals(
+            listOf(PrefKey.USE_L2CAP, PrefKey.CLEAR_BLE_CACHE),
+            controller.getRetrievalOptionsPrefs()
+        )
+        assertEquals(
+            listOf(PrefKey.BLE_CENTRAL_CLIENT, PrefKey.BLE_PERIPHERAL_SERVER),
+            controller.getRetrievalMethodPrefs()
+        )
+    }
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/core/extension/Base64ExtensionsTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/core/extension/Base64ExtensionsTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.core.extension
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class Base64ExtensionsTest {
+
+    // region encodeToBase64String
+
+    @Test
+    fun `encode and decode round-trips with url-safe padded default`() {
+        val bytes = "Hello, EUDI!".encodeToByteArray()
+
+        val encoded = bytes.encodeToBase64String()
+        val decoded = encoded.decodeBase64ToBytesOrNull()
+
+        assertContentEquals(bytes, decoded)
+    }
+
+    @Test
+    fun `encode without padding omits the trailing padding characters`() {
+        val bytes = byteArrayOf(1, 2, 3, 4, 5)
+
+        val padded = bytes.encodeToBase64String(withPadding = true)
+        val unpadded = bytes.encodeToBase64String(withPadding = false)
+
+        assertTrue(padded.endsWith("="))
+        assertTrue(!unpadded.contains("="))
+    }
+
+    @Test
+    fun `encode with the standard (non url-safe) alphabet is decodable`() {
+        // 0xFB, 0xFF encodes to characters that differ between the standard and url-safe alphabets.
+        val bytes = byteArrayOf(0xFB.toByte(), 0xFF.toByte())
+
+        val standard = bytes.encodeToBase64String(urlSafe = false)
+        val urlSafe = bytes.encodeToBase64String(urlSafe = true)
+
+        assertTrue(standard.any { it == '+' || it == '/' })
+        assertTrue(urlSafe.any { it == '-' || it == '_' })
+        assertContentEquals(bytes, urlSafe.decodeBase64ToBytesOrNull())
+    }
+
+    // endregion
+
+    // region decode
+
+    @Test
+    fun `decode strips a data-uri prefix before decoding`() {
+        val bytes = "abc".encodeToByteArray()
+        val dataUri = "data:text/plain;base64," + bytes.encodeToBase64String()
+
+        assertContentEquals(bytes, dataUri.decodeBase64ToBytesOrNull())
+    }
+
+    @Test
+    fun `decode returns null for blank input`() {
+        assertNull("".decodeBase64ToBytesOrNull())
+        assertNull("data:text/plain;base64,".decodeBase64ToBytesOrNull())
+    }
+
+    @Test
+    fun `decode returns null for malformed base64`() {
+        assertNull("!!!".decodeBase64ToBytesOrNull())
+    }
+
+    @Test
+    fun `decodeBase64ToUtf8OrNull round-trips a string`() {
+        val original = "héllo"
+
+        val encoded = original.encodeToByteArray().encodeToBase64String()
+
+        assertEquals(original, encoded.decodeBase64ToUtf8OrNull())
+    }
+
+    @Test
+    fun `decodeBase64ToUtf8OrNull returns null for malformed base64`() {
+        assertNull("!!!".decodeBase64ToUtf8OrNull())
+    }
+
+    // endregion
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/core/extension/FlowExtensionsTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/core/extension/FlowExtensionsTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.core.extension
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FlowExtensionsTest {
+
+    @Test
+    fun `safeAsync passes values through when no error occurs`() = runTest {
+        // Uses the default dispatcher (Dispatchers.IO) on purpose.
+        val result = flowOf(1, 2, 3)
+            .safeAsync { -1 }
+            .toList()
+
+        assertEquals(listOf(1, 2, 3), result)
+    }
+
+    @Test
+    fun `safeAsync emits the fallback value when the flow throws`() = runTest {
+        val failing = flow {
+            emit(1)
+            throw RuntimeException("boom")
+        }
+
+        val result = failing
+            .safeAsync(dispatcher = Dispatchers.Unconfined) { -1 }
+            .toList()
+
+        assertEquals(listOf(1, -1), result)
+    }
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/core/utils/SafeLetTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/core/utils/SafeLetTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.core.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SafeLetTest {
+
+    @Test
+    fun `safeLet invokes the block when both arguments are non-null`() {
+        val result = safeLet("a", 1) { p1, p2 -> "$p1$p2" }
+
+        assertEquals("a1", result)
+    }
+
+    @Test
+    fun `safeLet returns null when the first argument is null`() {
+        val first: String? = null
+
+        assertNull(safeLet(first, 1) { _, _ -> "block" })
+    }
+
+    @Test
+    fun `safeLet returns null when the second argument is null`() {
+        val second: Int? = null
+
+        assertNull(safeLet("a", second) { _, _ -> "block" })
+    }
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/config/model/AttestationTypeTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/config/model/AttestationTypeTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.domain.config.model
+
+import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType.Companion.getAttestationTypeFromDocType
+import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType.Companion.getDisplayName
+import eu.europa.ec.euidi.verifier.testutil.documentTypeResourceProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AttestationTypeTest {
+
+    private val resourceProvider = documentTypeResourceProvider()
+
+    @Test
+    fun `namespace and docType are exposed for each attestation type`() {
+        assertEquals("eu.europa.ec.eudi.pid.1", AttestationType.Pid.namespace)
+        assertEquals("eu.europa.ec.eudi.pid.1", AttestationType.Pid.docType)
+
+        assertEquals("org.iso.18013.5.1", AttestationType.Mdl.namespace)
+        assertEquals("org.iso.18013.5.1.mDL", AttestationType.Mdl.docType)
+
+        assertEquals("eu.europa.ec.eudi.employee.1", AttestationType.EmployeeId.namespace)
+        assertEquals("eu.europa.ec.eudi.employee.1", AttestationType.EmployeeId.docType)
+    }
+
+    @Test
+    fun `getDisplayName maps each type to its localized label`() {
+        assertEquals("PID", AttestationType.Pid.getDisplayName(resourceProvider))
+        assertEquals("MDL", AttestationType.Mdl.getDisplayName(resourceProvider))
+        assertEquals("Employee ID", AttestationType.EmployeeId.getDisplayName(resourceProvider))
+    }
+
+    @Test
+    fun `getAttestationTypeFromDocType resolves each known docType`() {
+        assertEquals(
+            AttestationType.Pid,
+            getAttestationTypeFromDocType(AttestationType.Pid.docType)
+        )
+        assertEquals(
+            AttestationType.Mdl,
+            getAttestationTypeFromDocType(AttestationType.Mdl.docType)
+        )
+        assertEquals(
+            AttestationType.EmployeeId,
+            getAttestationTypeFromDocType(AttestationType.EmployeeId.docType)
+        )
+    }
+
+    @Test
+    fun `getAttestationTypeFromDocType throws for an unknown docType`() {
+        assertFailsWith<IllegalArgumentException> {
+            getAttestationTypeFromDocType("unknown.doctype")
+        }
+    }
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/DocumentsToRequestInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/DocumentsToRequestInteractorTest.kt
@@ -19,18 +19,13 @@ package eu.europa.ec.euidi.verifier.domain.interactor
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
-import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
 import eu.europa.ec.euidi.verifier.domain.config.ConfigProvider
 import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType
-import eu.europa.ec.euidi.verifier.domain.config.model.ClaimItem
 import eu.europa.ec.euidi.verifier.domain.config.model.DocumentMode
 import eu.europa.ec.euidi.verifier.domain.config.model.SupportedDocuments
-import eu.europa.ec.euidi.verifier.domain.model.SupportedDocumentUi
 import eu.europa.ec.euidi.verifier.presentation.model.RequestedDocumentUi
-import eudiverifier.verifierapp.generated.resources.Res
-import eudiverifier.verifierapp.generated.resources.document_type_employee_id
-import eudiverifier.verifierapp.generated.resources.document_type_mdl
-import eudiverifier.verifierapp.generated.resources.document_type_pid
+import eu.europa.ec.euidi.verifier.testutil.TestData
+import eu.europa.ec.euidi.verifier.testutil.documentTypeResourceProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -57,7 +52,7 @@ class DocumentsToRequestInteractorTest {
         val dispatcher = coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
         return DocumentsToRequestInteractorImpl(
             configProvider = configProvider(supportedDocuments),
-            resourceProvider = stringResourceProvider(),
+            resourceProvider = documentTypeResourceProvider(),
             dispatcher = dispatcher
         )
     }
@@ -69,8 +64,8 @@ class DocumentsToRequestInteractorTest {
         runTest(StandardTestDispatcher()) {
             val supportedDocs = SupportedDocuments(
                 documents = mapOf(
-                    AttestationType.Pid to listOf(ClaimItem("family_name")),
-                    AttestationType.Mdl to listOf(ClaimItem("given_name"))
+                    AttestationType.Pid to listOf(TestData.familyNameClaim),
+                    AttestationType.Mdl to listOf(TestData.givenNameClaim)
                 )
             )
 
@@ -100,10 +95,7 @@ class DocumentsToRequestInteractorTest {
     @Test
     fun `getDocumentClaims returns configured claims for attestation type`() =
         runTest(StandardTestDispatcher()) {
-            val pidClaims = listOf(
-                ClaimItem("family_name"),
-                ClaimItem("age")
-            )
+            val pidClaims = TestData.pidClaims
             val supportedDocs = SupportedDocuments(
                 documents = mapOf(
                     AttestationType.Pid to pidClaims
@@ -122,7 +114,7 @@ class DocumentsToRequestInteractorTest {
         runTest(StandardTestDispatcher()) {
             val supportedDocs = SupportedDocuments(
                 documents = mapOf(
-                    AttestationType.Pid to listOf(ClaimItem("family_name"))
+                    AttestationType.Pid to listOf(TestData.familyNameClaim)
                 )
             )
 
@@ -142,12 +134,7 @@ class DocumentsToRequestInteractorTest {
         runTest(StandardTestDispatcher()) {
             val interactor = createInteractor()
             val currentDocs = listOf(
-                RequestedDocumentUi(
-                    id = "PID_DOC",
-                    documentType = AttestationType.Pid,
-                    mode = DocumentMode.FULL,
-                    claims = emptyList()
-                )
+                TestData.pidFullRequestedDocument
             )
 
             val result = interactor.handleDocumentOptionSelection(
@@ -165,12 +152,7 @@ class DocumentsToRequestInteractorTest {
         runTest(StandardTestDispatcher()) {
             val interactor = createInteractor()
             val currentDocs = listOf(
-                RequestedDocumentUi(
-                    id = "PID_DOC",
-                    documentType = AttestationType.Pid,
-                    mode = DocumentMode.FULL,
-                    claims = emptyList()
-                )
+                TestData.pidFullRequestedDocument
             )
 
             val result = interactor.handleDocumentOptionSelection(
@@ -210,10 +192,7 @@ class DocumentsToRequestInteractorTest {
     @Test
     fun `handleDocumentOptionSelection full mode adds new doc with all claims when none selected`() =
         runTest(StandardTestDispatcher()) {
-            val pidClaims = listOf(
-                ClaimItem("family_name"),
-                ClaimItem("age")
-            )
+            val pidClaims = TestData.pidClaims
             val supportedDocs = SupportedDocuments(
                 documents = mapOf(AttestationType.Pid to pidClaims)
             )
@@ -238,10 +217,7 @@ class DocumentsToRequestInteractorTest {
     @Test
     fun `handleDocumentOptionSelection full mode replaces existing custom doc for same type`() =
         runTest(StandardTestDispatcher()) {
-            val pidClaims = listOf(
-                ClaimItem("family_name"),
-                ClaimItem("age")
-            )
+            val pidClaims = TestData.pidClaims
             val supportedDocs = SupportedDocuments(
                 documents = mapOf(AttestationType.Pid to pidClaims)
             )
@@ -253,7 +229,7 @@ class DocumentsToRequestInteractorTest {
                     id = "PID_DOC",
                     documentType = AttestationType.Pid,
                     mode = DocumentMode.CUSTOM,
-                    claims = listOf(ClaimItem("family_name")) // subset
+                    claims = listOf(TestData.familyNameClaim) // subset
                 )
             )
 
@@ -274,7 +250,7 @@ class DocumentsToRequestInteractorTest {
     @Test
     fun `handleDocumentOptionSelection full mode keeps other document types`() =
         runTest(StandardTestDispatcher()) {
-            val pidClaims = listOf(ClaimItem("family_name"))
+            val pidClaims = listOf(TestData.familyNameClaim)
             val supportedDocs = SupportedDocuments(
                 documents = mapOf(AttestationType.Pid to pidClaims)
             )
@@ -282,12 +258,7 @@ class DocumentsToRequestInteractorTest {
             val interactor = createInteractor(supportedDocs)
 
             val currentDocs = listOf(
-                RequestedDocumentUi(
-                    id = "MDL_DOC",
-                    documentType = AttestationType.Mdl,
-                    mode = DocumentMode.FULL,
-                    claims = emptyList()
-                )
+                TestData.mdlFullRequestedDocument
             )
 
             val result = interactor.handleDocumentOptionSelection(
@@ -308,24 +279,14 @@ class DocumentsToRequestInteractorTest {
         runTest(StandardTestDispatcher()) {
             val interactor = createInteractor()
             val currentDocs = listOf(
-                RequestedDocumentUi(
-                    id = "PID_DOC",
-                    documentType = AttestationType.Pid,
-                    mode = DocumentMode.FULL,
-                    claims = emptyList()
-                ),
+                TestData.pidFullRequestedDocument,
                 RequestedDocumentUi(
                     id = "PID_CUSTOM",
                     documentType = AttestationType.Pid,
                     mode = DocumentMode.CUSTOM,
                     claims = emptyList()
                 ),
-                RequestedDocumentUi(
-                    id = "MDL_DOC",
-                    documentType = AttestationType.Mdl,
-                    mode = DocumentMode.FULL,
-                    claims = emptyList()
-                )
+                TestData.mdlFullRequestedDocument
             )
 
             val result = interactor.handleDocumentOptionSelection(
@@ -350,12 +311,7 @@ class DocumentsToRequestInteractorTest {
         runTest(StandardTestDispatcher()) {
             val interactor = createInteractor()
             val currentDocs = listOf(
-                RequestedDocumentUi(
-                    id = "MDL_DOC",
-                    documentType = AttestationType.Mdl,
-                    mode = DocumentMode.FULL,
-                    claims = emptyList()
-                )
+                TestData.mdlFullRequestedDocument
             )
 
             val result = interactor.handleDocumentOptionSelection(
@@ -373,7 +329,7 @@ class DocumentsToRequestInteractorTest {
     @Test
     fun `handleDocumentOptionSelection full mode appends when same type and mode exist under another id`() =
         runTest(StandardTestDispatcher()) {
-            val pidClaims = listOf(ClaimItem("family_name"))
+            val pidClaims = listOf(TestData.familyNameClaim)
             val supportedDocs = SupportedDocuments(
                 documents = mapOf(AttestationType.Pid to pidClaims)
             )
@@ -411,18 +367,7 @@ class DocumentsToRequestInteractorTest {
     @Test
     fun `searchDocuments filters by document display name`() =
         runTest(StandardTestDispatcher()) {
-            val docs = listOf(
-                SupportedDocumentUi(
-                    id = "PID",
-                    documentType = AttestationType.Pid,
-                    modes = listOf(DocumentMode.FULL)
-                ),
-                SupportedDocumentUi(
-                    id = "MDL",
-                    documentType = AttestationType.Mdl,
-                    modes = listOf(DocumentMode.CUSTOM)
-                )
-            )
+            val docs = TestData.searchableSupportedDocuments
 
             val interactor = createInteractor()
 
@@ -438,18 +383,7 @@ class DocumentsToRequestInteractorTest {
     @Test
     fun `searchDocuments ignores case sensitivity when searching by display name`() =
         runTest(StandardTestDispatcher()) {
-            val docs = listOf(
-                SupportedDocumentUi(
-                    id = "PID",
-                    documentType = AttestationType.Pid,
-                    modes = listOf(DocumentMode.FULL)
-                ),
-                SupportedDocumentUi(
-                    id = "MDL",
-                    documentType = AttestationType.Mdl,
-                    modes = listOf(DocumentMode.CUSTOM)
-                )
-            )
+            val docs = TestData.searchableSupportedDocuments
 
             val interactor = createInteractor()
             val result = interactor.searchDocuments(
@@ -464,18 +398,7 @@ class DocumentsToRequestInteractorTest {
     @Test
     fun `searchDocuments filters by document mode display name`() =
         runTest(StandardTestDispatcher()) {
-            val docs = listOf(
-                SupportedDocumentUi(
-                    id = "PID",
-                    documentType = AttestationType.Pid,
-                    modes = listOf(DocumentMode.FULL)
-                ),
-                SupportedDocumentUi(
-                    id = "MDL",
-                    documentType = AttestationType.Mdl,
-                    modes = listOf(DocumentMode.CUSTOM)
-                )
-            )
+            val docs = TestData.searchableSupportedDocuments
 
             val interactor = createInteractor()
 
@@ -491,18 +414,7 @@ class DocumentsToRequestInteractorTest {
     @Test
     fun `searchDocuments filters by document mode display name ignoring case sensitivity`() =
         runTest(StandardTestDispatcher()) {
-            val docs = listOf(
-                SupportedDocumentUi(
-                    id = "PID",
-                    documentType = AttestationType.Pid,
-                    modes = listOf(DocumentMode.FULL)
-                ),
-                SupportedDocumentUi(
-                    id = "MDL",
-                    documentType = AttestationType.Mdl,
-                    modes = listOf(DocumentMode.CUSTOM)
-                )
-            )
+            val docs = TestData.searchableSupportedDocuments
 
             val interactor = createInteractor()
             val result = interactor.searchDocuments(
@@ -517,18 +429,7 @@ class DocumentsToRequestInteractorTest {
     @Test
     fun `searchDocuments returns empty list when no matches`() =
         runTest(StandardTestDispatcher()) {
-            val docs = listOf(
-                SupportedDocumentUi(
-                    id = "PID",
-                    documentType = AttestationType.Pid,
-                    modes = listOf(DocumentMode.FULL)
-                ),
-                SupportedDocumentUi(
-                    id = "MDL",
-                    documentType = AttestationType.Mdl,
-                    modes = listOf(DocumentMode.CUSTOM)
-                )
-            )
+            val docs = TestData.searchableSupportedDocuments
 
             val interactor = createInteractor()
             val result = interactor.searchDocuments(
@@ -546,10 +447,7 @@ class DocumentsToRequestInteractorTest {
     @Test
     fun `checkDocumentMode sets mode to FULL when all claims are selected`() =
         runTest(StandardTestDispatcher()) {
-            val pidClaims = listOf(
-                ClaimItem("family_name"),
-                ClaimItem("age")
-            )
+            val pidClaims = TestData.pidClaims
             val supportedDocs = SupportedDocuments(
                 documents = mapOf(AttestationType.Pid to pidClaims)
             )
@@ -575,10 +473,7 @@ class DocumentsToRequestInteractorTest {
     @Test
     fun `checkDocumentMode keeps mode when not all claims are selected`() =
         runTest(StandardTestDispatcher()) {
-            val pidClaims = listOf(
-                ClaimItem("family_name"),
-                ClaimItem("age")
-            )
+            val pidClaims = TestData.pidClaims
             val supportedDocs = SupportedDocuments(
                 documents = mapOf(AttestationType.Pid to pidClaims)
             )
@@ -590,7 +485,7 @@ class DocumentsToRequestInteractorTest {
                     id = "PID_DOC",
                     documentType = AttestationType.Pid,
                     mode = DocumentMode.CUSTOM,
-                    claims = listOf(ClaimItem("family_name")) // partial
+                    claims = listOf(TestData.familyNameClaim) // partial
                 )
             )
 
@@ -612,7 +507,7 @@ class DocumentsToRequestInteractorTest {
                     id = "PID_DOC",
                     documentType = AttestationType.Pid,
                     mode = DocumentMode.CUSTOM,
-                    claims = listOf(ClaimItem("family_name"))
+                    claims = listOf(TestData.familyNameClaim)
                 )
             )
 
@@ -638,16 +533,6 @@ class DocumentsToRequestInteractorTest {
             configProvider.getDocumentModes(AttestationType.EmployeeId)
         } returns emptyList()
         return configProvider
-    }
-
-    private fun stringResourceProvider(): ResourceProvider {
-        val resourceProvider = mock<ResourceProvider>()
-        every { resourceProvider.getSharedString(Res.string.document_type_pid) } returns "PID"
-        every { resourceProvider.getSharedString(Res.string.document_type_mdl) } returns "MDL"
-        every {
-            resourceProvider.getSharedString(Res.string.document_type_employee_id)
-        } returns "EMPLOYEE_ID"
-        return resourceProvider
     }
 
     // endregion

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/HomeInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/HomeInteractorTest.kt
@@ -17,7 +17,6 @@
 package eu.europa.ec.euidi.verifier.domain.interactor
 
 import dev.mokkery.MockMode
-import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
@@ -26,17 +25,14 @@ import dev.mokkery.verify.VerifyMode.Companion.exactly
 import eu.europa.ec.euidi.verifier.core.controller.PlatformController
 import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
 import eu.europa.ec.euidi.verifier.core.provider.UuidProvider
-import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType
-import eu.europa.ec.euidi.verifier.domain.config.model.DocumentMode
 import eu.europa.ec.euidi.verifier.presentation.component.AppIcons
 import eu.europa.ec.euidi.verifier.presentation.component.ListItemDataUi
 import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDataUi
 import eu.europa.ec.euidi.verifier.presentation.component.ListItemTrailingContentDataUi
-import eu.europa.ec.euidi.verifier.presentation.model.RequestedDocumentUi
+import eu.europa.ec.euidi.verifier.testutil.TestData
+import eu.europa.ec.euidi.verifier.testutil.documentTypeResourceProvider
+import eu.europa.ec.euidi.verifier.testutil.sequentialUuidProvider
 import eudiverifier.verifierapp.generated.resources.Res
-import eudiverifier.verifierapp.generated.resources.document_type_employee_id
-import eudiverifier.verifierapp.generated.resources.document_type_mdl
-import eudiverifier.verifierapp.generated.resources.document_type_pid
 import eudiverifier.verifierapp.generated.resources.home_screen_main_button_text_default
 import eudiverifier.verifierapp.generated.resources.home_screen_main_button_text_separator
 import eudiverifier.verifierapp.generated.resources.home_screen_title
@@ -123,14 +119,7 @@ class HomeInteractorTest {
                 )
             )
 
-            val requestedDocs = listOf(
-                RequestedDocumentUi(
-                    id = "PID_DOC",
-                    documentType = AttestationType.Pid,
-                    mode = DocumentMode.FULL,
-                    claims = emptyList()
-                )
-            )
+            val requestedDocs = listOf(TestData.pidFullRequestedDocument)
 
             val updated = interactor.formatMainButtonData(
                 requestedDocs = requestedDocs,
@@ -164,18 +153,8 @@ class HomeInteractorTest {
             )
 
             val requestedDocs = listOf(
-                RequestedDocumentUi(
-                    id = "PID_DOC",
-                    documentType = AttestationType.Pid,
-                    mode = DocumentMode.FULL,
-                    claims = emptyList()
-                ),
-                RequestedDocumentUi(
-                    id = "MDL_DOC",
-                    documentType = AttestationType.Mdl,
-                    mode = DocumentMode.CUSTOM,
-                    claims = emptyList()
-                )
+                TestData.pidFullRequestedDocument,
+                TestData.mdlCustomRequestedDocument,
             )
 
             val updated = interactor.formatMainButtonData(
@@ -206,22 +185,18 @@ class HomeInteractorTest {
 
     //region Mocks
 
-    private fun sequentialUuidProvider(): UuidProvider {
-        var counter = 0
-        return mock {
-            every { provideUuid() } calls { "uuid-${counter++}" }
-        }
-    }
-
-    private fun stringResourceProvider(): ResourceProvider = mock {
-        every { getSharedString(Res.string.home_screen_title) } returns "Home Screen title"
+    private fun stringResourceProvider(): ResourceProvider {
+        val resourceProvider = documentTypeResourceProvider()
         every {
-            getSharedString(Res.string.home_screen_main_button_text_default)
+            resourceProvider.getSharedString(Res.string.home_screen_title)
+        } returns "Home Screen title"
+        every {
+            resourceProvider.getSharedString(Res.string.home_screen_main_button_text_default)
         } returns "Home Screen main button text default"
-        every { getSharedString(Res.string.home_screen_main_button_text_separator) } returns " ; "
-        every { getSharedString(Res.string.document_type_pid) } returns "PID"
-        every { getSharedString(Res.string.document_type_mdl) } returns "MDL"
-        every { getSharedString(Res.string.document_type_employee_id) } returns "Employee ID"
+        every {
+            resourceProvider.getSharedString(Res.string.home_screen_main_button_text_separator)
+        } returns " ; "
+        return resourceProvider
     }
 
     //endregion

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/MenuInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/MenuInteractorTest.kt
@@ -16,7 +16,6 @@
 
 package eu.europa.ec.euidi.verifier.domain.interactor
 
-import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
@@ -28,6 +27,7 @@ import eu.europa.ec.euidi.verifier.presentation.component.ListItemLeadingContent
 import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDataUi
 import eu.europa.ec.euidi.verifier.presentation.component.ListItemTrailingContentDataUi
 import eu.europa.ec.euidi.verifier.presentation.ui.menu.model.MenuTypeUi
+import eu.europa.ec.euidi.verifier.testutil.sequentialUuidProvider
 import eudiverifier.verifierapp.generated.resources.Res
 import eudiverifier.verifierapp.generated.resources.menu_screen_item_home_name
 import eudiverifier.verifierapp.generated.resources.menu_screen_item_settings_name
@@ -134,13 +134,6 @@ class MenuInteractorTest {
     //endregion
 
     //region Mocks
-
-    private fun sequentialUuidProvider(): UuidProvider {
-        var counter = 0
-        return mock {
-            every { provideUuid() } calls { "uuid-${counter++}" }
-        }
-    }
 
     private fun stringResourceProvider(): ResourceProvider = mock {
         every { getSharedString(Res.string.menu_screen_title) } returns "Menu title"

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/SettingsInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/SettingsInteractorTest.kt
@@ -33,6 +33,7 @@ import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDat
 import eu.europa.ec.euidi.verifier.presentation.component.ListItemTrailingContentDataUi
 import eu.europa.ec.euidi.verifier.presentation.ui.settings.model.SettingsItemUi
 import eu.europa.ec.euidi.verifier.presentation.ui.settings.model.SettingsTypeUi
+import eu.europa.ec.euidi.verifier.testutil.sequentialUuidProvider
 import eudiverifier.verifierapp.generated.resources.Res
 import eudiverifier.verifierapp.generated.resources.settings_screen_category_data_retrieval_methods_description
 import eudiverifier.verifierapp.generated.resources.settings_screen_category_data_retrieval_methods_title
@@ -260,13 +261,6 @@ class SettingsInteractorTest {
     //endregion
 
     //region Mocks
-
-    private fun sequentialUuidProvider(): UuidProvider {
-        var counter = 0
-        return mock {
-            every { provideUuid() } calls { "uuid-${counter++}" }
-        }
-    }
 
     /**
      * Mocks the [DataStoreController]. The three pref-grouping lists mirror production so the

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/ShowDocumentsInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/ShowDocumentsInteractorTest.kt
@@ -27,6 +27,7 @@ import eu.europa.ec.euidi.verifier.domain.config.model.ClaimItem
 import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDataUi
 import eu.europa.ec.euidi.verifier.presentation.model.ReceivedDocumentUi
 import eu.europa.ec.euidi.verifier.presentation.ui.show_document.model.DocumentValidityUi
+import eu.europa.ec.euidi.verifier.testutil.sequentialUuidProvider
 import eudiverifier.verifierapp.generated.resources.Res
 import eudiverifier.verifierapp.generated.resources.document_type_pid
 import eudiverifier.verifierapp.generated.resources.show_documents_screen_title
@@ -120,13 +121,6 @@ class ShowDocumentsInteractorTest {
     //endregion
 
     //region Mocks
-
-    private fun sequentialUuidProvider(): UuidProvider {
-        var counter = 0
-        return mock {
-            every { provideUuid() } calls { "uuid-${counter++}" }
-        }
-    }
 
     /**
      * The interactor resolves claim translations dynamically via `UiTransformer.getClaimTranslation`,

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/TransferStatusInteractorTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/interactor/TransferStatusInteractorTest.kt
@@ -34,16 +34,13 @@ import eu.europa.ec.euidi.verifier.core.provider.UuidProvider
 import eu.europa.ec.euidi.verifier.domain.config.ConfigProvider
 import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType
 import eu.europa.ec.euidi.verifier.domain.config.model.ClaimItem
-import eu.europa.ec.euidi.verifier.domain.config.model.DocumentMode
 import eu.europa.ec.euidi.verifier.domain.config.model.Logger
 import eu.europa.ec.euidi.verifier.domain.model.DocumentValidityDomain
 import eu.europa.ec.euidi.verifier.domain.model.ReceivedDocumentDomain
-import eu.europa.ec.euidi.verifier.presentation.model.RequestedDocumentUi
-import eu.europa.ec.euidi.verifier.presentation.ui.show_document.model.DocumentValidityUi
+import eu.europa.ec.euidi.verifier.testutil.TestData
+import eu.europa.ec.euidi.verifier.testutil.documentTypeResourceProvider
+import eu.europa.ec.euidi.verifier.testutil.sequentialUuidProvider
 import eudiverifier.verifierapp.generated.resources.Res
-import eudiverifier.verifierapp.generated.resources.document_type_employee_id
-import eudiverifier.verifierapp.generated.resources.document_type_mdl
-import eudiverifier.verifierapp.generated.resources.document_type_pid
 import eudiverifier.verifierapp.generated.resources.transfer_status_screen_request_label
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -117,17 +114,7 @@ class TransferStatusInteractorTest {
             assertEquals("uuid-0", doc.id)
             assertEquals(AttestationType.Pid, doc.documentType)
             assertEquals(mapOf(ClaimItem("given_name") to "John"), doc.claims)
-            assertEquals(
-                DocumentValidityUi(
-                    isDeviceSignatureValid = true,
-                    isIssuerSignatureValid = true,
-                    isDataIntegrityIntact = true,
-                    signed = null,
-                    validFrom = null,
-                    validUntil = null,
-                ),
-                doc.documentValidity
-            )
+            assertEquals(TestData.validDocumentValidityUi, doc.documentValidity)
         }
 
     @Test
@@ -236,13 +223,7 @@ class TransferStatusInteractorTest {
                 dataStoreController = dataStore(stored = mapOf(PrefKey.RETAIN_DATA to true))
             )
 
-            val docs = listOf(
-                RequestedDocumentUi(
-                    id = "PID_DOC",
-                    documentType = AttestationType.Pid,
-                    mode = DocumentMode.FULL,
-                )
-            )
+            val docs = listOf(TestData.pidFullRequestedDocument)
 
             val status = interactor.getConnectionStatus(docs).first()
 
@@ -260,16 +241,8 @@ class TransferStatusInteractorTest {
             val interactor = createInteractor()
 
             val docs = listOf(
-                RequestedDocumentUi(
-                    id = "PID_DOC",
-                    documentType = AttestationType.Pid,
-                    mode = DocumentMode.FULL,
-                ),
-                RequestedDocumentUi(
-                    id = "MDL_DOC",
-                    documentType = AttestationType.Mdl,
-                    mode = DocumentMode.CUSTOM,
-                )
+                TestData.pidFullRequestedDocument,
+                TestData.mdlCustomRequestedDocument,
             )
 
             val result = interactor.getRequestData(docs)
@@ -306,13 +279,6 @@ class TransferStatusInteractorTest {
 
     //region Mocks
 
-    private fun sequentialUuidProvider(): UuidProvider {
-        var counter = 0
-        return mock {
-            every { provideUuid() } calls { "uuid-${counter++}" }
-        }
-    }
-
     private fun transferController(
         statusFlow: Flow<TransferStatus> = flowOf(TransferStatus.Connected)
     ): TransferController {
@@ -345,15 +311,10 @@ class TransferStatusInteractorTest {
     }
 
     private fun stringResourceProvider(): ResourceProvider {
-        val resourceProvider = mock<ResourceProvider>()
+        val resourceProvider = documentTypeResourceProvider()
         every {
             resourceProvider.getSharedString(Res.string.transfer_status_screen_request_label)
         } returns "Requesting:"
-        every { resourceProvider.getSharedString(Res.string.document_type_pid) } returns "PID"
-        every { resourceProvider.getSharedString(Res.string.document_type_mdl) } returns "MDL"
-        every {
-            resourceProvider.getSharedString(Res.string.document_type_employee_id)
-        } returns "Employee ID"
         return resourceProvider
     }
 

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/transformer/UiTransformerTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/domain/transformer/UiTransformerTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.domain.transformer
+
+import dev.mokkery.answering.calls
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
+import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType
+import eu.europa.ec.euidi.verifier.domain.config.model.ClaimItem
+import eu.europa.ec.euidi.verifier.domain.transformer.UiTransformer.toListItemDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemLeadingContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemTrailingContentDataUi
+import eu.europa.ec.euidi.verifier.testutil.TestData
+import org.jetbrains.compose.resources.StringResource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class UiTransformerTest {
+
+    // Resolves any string resource to a constant, so claim-translation lookups never fail.
+    private val resourceProvider: ResourceProvider = mock {
+        every { getSharedString(any()) } calls { (_: StringResource) -> "label" }
+    }
+
+    private val document = TestData.pidReceivedDocument
+
+    //region transformToUiItems
+
+    @Test
+    fun `transformToUiItems returns an empty list for empty fields`() {
+        val result = UiTransformer.transformToUiItems(
+            fields = emptyList(),
+            attestationType = AttestationType.Pid,
+            resourceProvider = resourceProvider,
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `transformToUiItems maps each claim to a checked checkbox item`() {
+        val claims = listOf(ClaimItem("given_name"), ClaimItem("family_name"))
+
+        val result = UiTransformer.transformToUiItems(
+            fields = claims,
+            attestationType = AttestationType.Pid,
+            resourceProvider = resourceProvider,
+        )
+
+        assertEquals(2, result.size)
+        result.forEachIndexed { index, item ->
+            assertEquals(claims[index].label, item.itemId)
+            assertIs<ListItemMainContentDataUi.Text>(item.mainContentData)
+            val trailing = item.trailingContentData
+            assertIs<ListItemTrailingContentDataUi.Checkbox>(trailing)
+            assertTrue(trailing.checkboxData.isChecked)
+        }
+    }
+
+    //endregion
+
+    //region toListItemDataUi content types
+
+    @Test
+    fun `toListItemDataUi renders a portrait claim as a user image with empty main text`() {
+        val item = document.toListItemDataUi(
+            itemId = "id",
+            claimKey = ClaimItem("portrait"),
+            claimValue = "base64-portrait",
+            resourceProvider = resourceProvider,
+        )
+
+        val main = item.mainContentData
+        assertIs<ListItemMainContentDataUi.Text>(main)
+        assertEquals("", main.text)
+
+        val leading = item.leadingContentData
+        assertIs<ListItemLeadingContentDataUi.UserImage>(leading)
+        assertEquals("base64-portrait", leading.userBase64Image)
+    }
+
+    @Test
+    fun `toListItemDataUi renders a signature claim as an image`() {
+        val item = document.toListItemDataUi(
+            itemId = "id",
+            claimKey = ClaimItem("signature_usual_mark"),
+            claimValue = "base64-signature",
+            resourceProvider = resourceProvider,
+        )
+
+        val main = item.mainContentData
+        assertIs<ListItemMainContentDataUi.Image>(main)
+        assertEquals("base64-signature", main.base64Image)
+        assertNull(item.leadingContentData)
+    }
+
+    @Test
+    fun `toListItemDataUi renders a regular claim as text`() {
+        val item = document.toListItemDataUi(
+            itemId = "id",
+            claimKey = ClaimItem("given_name"),
+            claimValue = "John",
+            resourceProvider = resourceProvider,
+        )
+
+        val main = item.mainContentData
+        assertIs<ListItemMainContentDataUi.Text>(main)
+        assertEquals("John", main.text)
+        assertNull(item.leadingContentData)
+    }
+
+    //endregion
+
+    //region getClaimTranslation
+
+    @Test
+    fun `getClaimTranslation resolves a matching string resource when one exists`() {
+        // "home" + "screen_title" -> resource key "home_screen_title", which exists.
+        val result = UiTransformer.getClaimTranslation(
+            attestationType = "home",
+            claimLabel = "screen_title",
+            resourceProvider = resourceProvider,
+        )
+
+        assertEquals("label", result)
+    }
+
+    @Test
+    fun `getClaimTranslation falls back to the claim label when no resource matches`() {
+        val result = UiTransformer.getClaimTranslation(
+            attestationType = "PID",
+            claimLabel = "no_such_claim_key",
+            resourceProvider = resourceProvider,
+        )
+
+        assertEquals("no_such_claim_key", result)
+    }
+
+    //endregion
+
+    //region key predicates
+
+    @Test
+    fun `key predicates classify document keys`() {
+        assertTrue(UiTransformer.keyIsPortrait("portrait"))
+        assertFalse(UiTransformer.keyIsPortrait("given_name"))
+
+        assertTrue(UiTransformer.keyIsSignature("signature_usual_mark"))
+        assertFalse(UiTransformer.keyIsSignature("given_name"))
+
+        assertTrue(UiTransformer.keyIsUserPseudonym("user_pseudonym"))
+        assertFalse(UiTransformer.keyIsUserPseudonym("given_name"))
+
+        assertTrue(UiTransformer.keyIsGender("gender"))
+        assertTrue(UiTransformer.keyIsGender("sex"))
+        assertFalse(UiTransformer.keyIsGender("given_name"))
+    }
+
+    //endregion
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/MviViewModelTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/MviViewModelTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.presentation
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+
+/**
+ * Base class for [eu.europa.ec.euidi.verifier.presentation.architecture.MviViewModel] tests.
+ *
+ * `viewModelScope` runs on [Dispatchers.Main], so it is replaced with a test dispatcher for the
+ * duration of each test. An [UnconfinedTestDispatcher] is used so that the event collector started
+ * in the ViewModel's `init` subscribes eagerly and events dispatched via `setEvent` are processed
+ * synchronously — removing the need to manually advance the scheduler in most cases.
+ *
+ * The same [testDispatcher] should be passed to `runTest` so the ViewModel and the test body share
+ * a single scheduler.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+abstract class MviViewModelTest {
+
+    protected val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUpMainDispatcher() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDownMainDispatcher() {
+        Dispatchers.resetMain()
+    }
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/component/extension/ListItemDataExtensionsTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/component/extension/ListItemDataExtensionsTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.presentation.component.extension
+
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemTrailingContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.wrap.CheckboxDataUi
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ListItemDataExtensionsTest {
+
+    private fun item(id: String, trailing: ListItemTrailingContentDataUi? = null) = ListItemDataUi(
+        itemId = id,
+        mainContentData = ListItemMainContentDataUi.Text(id),
+        trailingContentData = trailing,
+    )
+
+    private fun checkbox(checked: Boolean) =
+        ListItemTrailingContentDataUi.Checkbox(CheckboxDataUi(isChecked = checked))
+
+    @Test
+    fun `hasAnyCheckedCheckbox is true when at least one checkbox is checked`() {
+        val items = listOf(
+            item("a", checkbox(checked = false)),
+            item("b", checkbox(checked = true)),
+        )
+
+        assertTrue(items.hasAnyCheckedCheckbox())
+    }
+
+    @Test
+    fun `hasAnyCheckedCheckbox is false when all checkboxes are unchecked`() {
+        val items = listOf(item("a", checkbox(checked = false)))
+
+        assertFalse(items.hasAnyCheckedCheckbox())
+    }
+
+    @Test
+    fun `hasAnyCheckedCheckbox is false when there are no checkbox items`() {
+        val items = listOf(item("a"))
+
+        assertFalse(items.hasAnyCheckedCheckbox())
+    }
+
+    @Test
+    fun `hasAnyCheckedCheckbox is false for an empty list`() {
+        assertFalse(emptyList<ListItemDataUi>().hasAnyCheckedCheckbox())
+    }
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/custom_request/CustomRequestViewModelTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/custom_request/CustomRequestViewModelTest.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.presentation.ui.custom_request
+
+import app.cash.turbine.test
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType
+import eu.europa.ec.euidi.verifier.domain.interactor.CustomRequestInteractor
+import eu.europa.ec.euidi.verifier.domain.interactor.HandleItemSelectionPartialState
+import eu.europa.ec.euidi.verifier.presentation.MviViewModelTest
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemTrailingContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.wrap.CheckboxDataUi
+import eu.europa.ec.euidi.verifier.presentation.model.RequestedDocsHolder
+import eu.europa.ec.euidi.verifier.presentation.ui.custom_request.CustomRequestContract.Effect
+import eu.europa.ec.euidi.verifier.presentation.ui.custom_request.CustomRequestContract.Event
+import eu.europa.ec.euidi.verifier.presentation.ui.custom_request.CustomRequestContract.State
+import eu.europa.ec.euidi.verifier.testutil.TestData
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CustomRequestViewModelTest : MviViewModelTest() {
+
+    private val doc = TestData.pidCustomRequestedDocument
+    private val claims = listOf(TestData.familyNameClaim)
+
+    private fun checkboxItem(id: String, checked: Boolean) = ListItemDataUi(
+        itemId = id,
+        mainContentData = ListItemMainContentDataUi.Text(id),
+        trailingContentData = ListItemTrailingContentDataUi.Checkbox(
+            checkboxData = CheckboxDataUi(isChecked = checked)
+        )
+    )
+
+    private val nonCheckboxItem = ListItemDataUi(
+        itemId = "header",
+        mainContentData = ListItemMainContentDataUi.Text("header")
+    )
+
+    // A checkbox item (checked) plus a non-checkbox item, exercising both branches of the
+    // select-all mapping and the `areAllItemsChecked` computation.
+    private val uiItems = listOf(checkboxItem("family_name", checked = true), nonCheckboxItem)
+
+    private fun customRequestInteractor(): CustomRequestInteractor = mock {
+        every { getDocumentClaims(AttestationType.Pid) } returns claims
+        everySuspend { transformToUiItems(AttestationType.Pid, claims) } returns uiItems
+        everySuspend { getScreenTitle(AttestationType.Pid) } returns "Custom PID"
+    }
+
+    @Test
+    fun `Init with a doc loads title, items and enables the primary button`() =
+        runTest(testDispatcher) {
+            val viewModel = CustomRequestViewModel(customRequestInteractor())
+
+            viewModel.setEvent(Event.Init(doc = doc))
+
+            val state = viewModel.uiState.value
+            assertEquals("Custom PID", state.screenTitle)
+            assertEquals(doc, state.requestedDoc)
+            assertEquals(uiItems, state.items)
+            assertTrue(state.primaryButtonEnabled)
+        }
+
+    @Test
+    fun `Init with no doc keeps the initial state`() = runTest(testDispatcher) {
+        val viewModel = CustomRequestViewModel(customRequestInteractor())
+
+        viewModel.setEvent(Event.Init(doc = null))
+
+        assertEquals(State(), viewModel.uiState.value)
+    }
+
+    @Test
+    fun `OnCancelClick goes back with no documents`() = runTest(testDispatcher) {
+        val viewModel = CustomRequestViewModel(customRequestInteractor())
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnCancelClick)
+            assertEquals(
+                Effect.Navigation.GoBack(RequestedDocsHolder(items = emptyList())),
+                awaitItem()
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `OnDoneClick goes back with the selected claims`() = runTest(testDispatcher) {
+        val selectedClaims = listOf(TestData.familyNameClaim)
+        val interactor = mock<CustomRequestInteractor> {
+            every { getDocumentClaims(AttestationType.Pid) } returns claims
+            everySuspend { transformToUiItems(AttestationType.Pid, claims) } returns uiItems
+            everySuspend { getScreenTitle(AttestationType.Pid) } returns "Custom PID"
+            everySuspend { transformToClaimItems(uiItems) } returns selectedClaims
+        }
+        val viewModel = CustomRequestViewModel(interactor)
+        viewModel.setEvent(Event.Init(doc = doc))
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnDoneClick)
+            val effect = awaitItem() as Effect.Navigation.GoBack
+            val returnedDoc = effect.requestedDocuments.items.single()
+            assertEquals(doc.id, returnedDoc.id)
+            assertEquals(selectedClaims, returnedDoc.claims)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `OnDoneClick without a requested doc does nothing`() = runTest(testDispatcher) {
+        val viewModel = CustomRequestViewModel(customRequestInteractor())
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnDoneClick)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `OnItemClicked applies the interactor selection result`() = runTest(testDispatcher) {
+        val toggledItems = listOf(checkboxItem("family_name", checked = false), nonCheckboxItem)
+        val interactor = mock<CustomRequestInteractor> {
+            every { getDocumentClaims(AttestationType.Pid) } returns claims
+            everySuspend { transformToUiItems(AttestationType.Pid, claims) } returns uiItems
+            everySuspend { getScreenTitle(AttestationType.Pid) } returns "Custom PID"
+            every {
+                handleItemSelection(uiItems, "family_name")
+            } returns HandleItemSelectionPartialState.Updated(
+                items = toggledItems,
+                hasSelectedItems = false
+            )
+        }
+        val viewModel = CustomRequestViewModel(interactor)
+        viewModel.setEvent(Event.Init(doc = doc))
+
+        viewModel.setEvent(Event.OnItemClicked("family_name"))
+
+        val state = viewModel.uiState.value
+        assertEquals(toggledItems, state.items)
+        assertFalse(state.primaryButtonEnabled)
+    }
+
+    @Test
+    fun `OnSelectAllClick unchecks every checkbox item and leaves others untouched`() =
+        runTest(testDispatcher) {
+            val viewModel = CustomRequestViewModel(customRequestInteractor())
+            viewModel.setEvent(Event.Init(doc = doc))
+
+            viewModel.setEvent(Event.OnSelectAllClick(isChecked = false))
+
+            val state = viewModel.uiState.value
+            val checkbox = state.items
+                .first { it.itemId == "family_name" }
+                .trailingContentData as ListItemTrailingContentDataUi.Checkbox
+            assertFalse(checkbox.checkboxData.isChecked)
+            // The non-checkbox item is preserved unchanged.
+            assertEquals(nonCheckboxItem, state.items.first { it.itemId == "header" })
+            assertFalse(state.primaryButtonEnabled)
+        }
+
+    @Test
+    fun `areAllItemsChecked is true only when every checkbox item is checked`() {
+        val allChecked = State(items = listOf(checkboxItem("a", checked = true), nonCheckboxItem))
+        val someUnchecked = State(items = listOf(checkboxItem("a", checked = false)))
+
+        assertTrue(allChecked.areAllItemsChecked)
+        assertFalse(someUnchecked.areAllItemsChecked)
+    }
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/doc_to_request/DocumentsToRequestViewModelTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/doc_to_request/DocumentsToRequestViewModelTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.presentation.ui.doc_to_request
+
+import app.cash.turbine.test
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType
+import eu.europa.ec.euidi.verifier.domain.config.model.DocumentMode
+import eu.europa.ec.euidi.verifier.domain.interactor.DocSelectionResult
+import eu.europa.ec.euidi.verifier.domain.interactor.DocumentsToRequestInteractor
+import eu.europa.ec.euidi.verifier.presentation.MviViewModelTest
+import eu.europa.ec.euidi.verifier.presentation.model.RequestedDocsHolder
+import eu.europa.ec.euidi.verifier.presentation.ui.doc_to_request.DocToRequestContract.Effect
+import eu.europa.ec.euidi.verifier.presentation.ui.doc_to_request.DocToRequestContract.Event
+import eu.europa.ec.euidi.verifier.testutil.TestData
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DocumentsToRequestViewModelTest : MviViewModelTest() {
+
+    private val supportedDocs = listOf(TestData.pidSupportedDocument)
+    private val pidDoc = TestData.pidFullRequestedDocument
+
+    private fun interactor(): DocumentsToRequestInteractor = mock {
+        everySuspend { getSupportedDocuments() } returns supportedDocs
+    }
+
+    @Test
+    fun `Init loads supported documents and applies the requested ones`() =
+        runTest(testDispatcher) {
+            val interactor = mock<DocumentsToRequestInteractor> {
+                everySuspend { getSupportedDocuments() } returns supportedDocs
+                everySuspend { checkDocumentMode(listOf(pidDoc)) } returns listOf(pidDoc)
+            }
+            val viewModel = DocumentsToRequestViewModel(interactor)
+
+            viewModel.setEvent(Event.Init(requestedDocs = RequestedDocsHolder(items = listOf(pidDoc))))
+
+            val state = viewModel.uiState.value
+            assertEquals(supportedDocs, state.allSupportedDocuments)
+            assertEquals(supportedDocs, state.filteredDocuments)
+            assertEquals(listOf(pidDoc), state.requestedDocuments)
+            assertTrue(state.isButtonEnabled)
+        }
+
+    @Test
+    fun `Init with no requested docs yields an empty selection`() = runTest(testDispatcher) {
+        val viewModel = DocumentsToRequestViewModel(interactor())
+
+        viewModel.setEvent(Event.Init(requestedDocs = null))
+
+        val state = viewModel.uiState.value
+        assertTrue(state.requestedDocuments.isEmpty())
+        assertFalse(state.isButtonEnabled)
+    }
+
+    @Test
+    fun `Init reuses already-loaded supported documents on a second call`() =
+        runTest(testDispatcher) {
+            val interactor = interactor()
+            val viewModel = DocumentsToRequestViewModel(interactor)
+
+            viewModel.setEvent(Event.Init(requestedDocs = null))
+            viewModel.setEvent(Event.Init(requestedDocs = null))
+
+            verifySuspend(exactly(1)) { interactor.getSupportedDocuments() }
+        }
+
+    @Test
+    fun `OnDocOptionSelected Updated stores the docs and enables the button`() =
+        runTest(testDispatcher) {
+            val interactor = mock<DocumentsToRequestInteractor> {
+                everySuspend { getSupportedDocuments() } returns supportedDocs
+                everySuspend {
+                    handleDocumentOptionSelection(any(), any(), any(), any())
+                } returns DocSelectionResult.Updated(listOf(pidDoc))
+            }
+            val viewModel = DocumentsToRequestViewModel(interactor)
+
+            viewModel.setEvent(
+                Event.OnDocOptionSelected("PID_DOC", AttestationType.Pid, DocumentMode.FULL)
+            )
+
+            val state = viewModel.uiState.value
+            assertEquals(listOf(pidDoc), state.requestedDocuments)
+            assertTrue(state.isButtonEnabled)
+        }
+
+    @Test
+    fun `OnDocOptionSelected NavigateToCustomRequest stores docs and emits the effect`() =
+        runTest(testDispatcher) {
+            val customDoc = TestData.pidCustomRequestedDocument
+            val interactor = mock<DocumentsToRequestInteractor> {
+                everySuspend { getSupportedDocuments() } returns supportedDocs
+                everySuspend {
+                    handleDocumentOptionSelection(any(), any(), any(), any())
+                } returns DocSelectionResult.NavigateToCustomRequest(emptyList(), customDoc)
+            }
+            val viewModel = DocumentsToRequestViewModel(interactor)
+
+            viewModel.effect.test {
+                viewModel.setEvent(
+                    Event.OnDocOptionSelected("PID_DOC", AttestationType.Pid, DocumentMode.CUSTOM)
+                )
+                assertEquals(
+                    Effect.Navigation.NavigateToCustomRequestScreen(customDoc),
+                    awaitItem()
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertEquals(emptyList(), viewModel.uiState.value.requestedDocuments)
+        }
+
+    @Test
+    fun `OnBackClick navigates to the home screen with no docs`() = runTest(testDispatcher) {
+        val viewModel = DocumentsToRequestViewModel(interactor())
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnBackClick)
+            assertEquals(Effect.Navigation.NavigateToHomeScreen(), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `OnDoneClick navigates to the home screen with the requested docs`() =
+        runTest(testDispatcher) {
+            val interactor = mock<DocumentsToRequestInteractor> {
+                everySuspend { getSupportedDocuments() } returns supportedDocs
+                everySuspend { checkDocumentMode(listOf(pidDoc)) } returns listOf(pidDoc)
+            }
+            val viewModel = DocumentsToRequestViewModel(interactor)
+            viewModel.setEvent(Event.Init(requestedDocs = RequestedDocsHolder(items = listOf(pidDoc))))
+
+            viewModel.effect.test {
+                viewModel.setEvent(Event.OnDoneClick)
+                assertEquals(
+                    Effect.Navigation.NavigateToHomeScreen(requestedDocuments = listOf(pidDoc)),
+                    awaitItem()
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `OnSearchQueryChanged updates the search term and filtered documents`() =
+        runTest(testDispatcher) {
+            val interactor = mock<DocumentsToRequestInteractor> {
+                everySuspend { getSupportedDocuments() } returns supportedDocs
+                every { searchDocuments("PID", supportedDocs) } returns flowOf(supportedDocs)
+            }
+            val viewModel = DocumentsToRequestViewModel(interactor)
+            viewModel.setEvent(Event.Init(requestedDocs = null)) // populates allSupportedDocuments
+
+            viewModel.setEvent(Event.OnSearchQueryChanged("PID"))
+
+            val state = viewModel.uiState.value
+            assertEquals("PID", state.searchTerm)
+            assertEquals(supportedDocs, state.filteredDocuments)
+        }
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/home/HomeViewModelTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/home/HomeViewModelTest.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.presentation.ui.home
+
+import app.cash.turbine.test
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import eu.europa.ec.euidi.verifier.domain.interactor.HomeInteractor
+import eu.europa.ec.euidi.verifier.presentation.MviViewModelTest
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.model.RequestedDocsHolder
+import eu.europa.ec.euidi.verifier.presentation.navigation.NavItem
+import eu.europa.ec.euidi.verifier.presentation.ui.home.HomeViewModelContract.Effect
+import eu.europa.ec.euidi.verifier.presentation.ui.home.HomeViewModelContract.Event
+import eu.europa.ec.euidi.verifier.testutil.TestData
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class HomeViewModelTest : MviViewModelTest() {
+
+    private val buttonData = ListItemDataUi(
+        itemId = "btn",
+        mainContentData = ListItemMainContentDataUi.Text("Create request")
+    )
+
+    private fun homeInteractor(): HomeInteractor = mock<HomeInteractor>(MockMode.autoUnit) {
+        every { getScreenTitle() } returns "Home"
+        every { getDefaultMainButtonData() } returns buttonData
+    }
+
+    //region OnResume
+
+    @Test
+    fun `OnResume with no docs loads title and default main button`() = runTest(testDispatcher) {
+        val viewModel = HomeViewModel(homeInteractor())
+
+        viewModel.setEvent(Event.OnResume(docs = null))
+
+        val state = viewModel.uiState.value
+        assertEquals("Home", state.screenTitle)
+        assertEquals(buttonData, state.mainButtonData)
+        assertFalse(state.isLoading)
+        assertTrue(state.requestedDocs.isEmpty())
+        assertFalse(state.isStickyButtonEnabled)
+    }
+
+    @Test
+    fun `OnResume with docs formats the main button and enables the sticky button`() =
+        runTest(testDispatcher) {
+            val docs = listOf(TestData.pidFullRequestedDocument)
+            val formattedButton = buttonData.copy(
+                mainContentData = ListItemMainContentDataUi.Text("Full PID")
+            )
+            val interactor = mock<HomeInteractor>(MockMode.autoUnit) {
+                every { getScreenTitle() } returns "Home"
+                every { getDefaultMainButtonData() } returns buttonData
+                everySuspend { formatMainButtonData(docs, buttonData) } returns formattedButton
+            }
+            val viewModel = HomeViewModel(interactor)
+
+            viewModel.setEvent(Event.OnResume(docs = docs))
+
+            val state = viewModel.uiState.value
+            assertEquals(docs, state.requestedDocs)
+            assertTrue(state.isStickyButtonEnabled)
+            assertEquals(formattedButton, state.mainButtonData)
+            assertFalse(state.isLoading)
+        }
+
+    @Test
+    fun `OnResume twice reuses the already-loaded main button without re-fetching`() =
+        runTest(testDispatcher) {
+            val docs = listOf(TestData.pidFullRequestedDocument)
+            val formattedButton = buttonData.copy(
+                mainContentData = ListItemMainContentDataUi.Text("Full PID")
+            )
+            val interactor = mock<HomeInteractor>(MockMode.autoUnit) {
+                every { getScreenTitle() } returns "Home"
+                every { getDefaultMainButtonData() } returns buttonData
+                everySuspend { formatMainButtonData(docs, buttonData) } returns formattedButton
+            }
+            val viewModel = HomeViewModel(interactor)
+
+            // First resume loads the default button; second resume must reuse it (no re-fetch).
+            viewModel.setEvent(Event.OnResume(docs = null))
+            viewModel.setEvent(Event.OnResume(docs = docs))
+
+            assertEquals(formattedButton, viewModel.uiState.value.mainButtonData)
+            verify(exactly(1)) { interactor.getScreenTitle() }
+            verify(exactly(1)) { interactor.getDefaultMainButtonData() }
+        }
+
+    //endregion
+
+    //region DismissError
+
+    @Test
+    fun `DismissError clears the error`() = runTest(testDispatcher) {
+        val viewModel = HomeViewModel(homeInteractor())
+
+        viewModel.setEvent(Event.DismissError)
+
+        assertNull(viewModel.uiState.value.error)
+    }
+
+    //endregion
+
+    //region OnBackClicked
+
+    @Test
+    fun `OnBackClicked delegates to the interactor to close the app`() = runTest(testDispatcher) {
+        val interactor = homeInteractor()
+        val viewModel = HomeViewModel(interactor)
+
+        viewModel.setEvent(Event.OnBackClicked)
+
+        verify(exactly(1)) { interactor.closeApp() }
+    }
+
+    //endregion
+
+    //region navigation effects
+
+    @Test
+    fun `OnStickyButtonClicked emits navigation to QR scan with the requested docs`() =
+        runTest(testDispatcher) {
+            val viewModel = HomeViewModel(homeInteractor())
+
+            viewModel.effect.test {
+                viewModel.setEvent(Event.OnStickyButtonClicked)
+
+                assertEquals(
+                    Effect.Navigation.SaveDocsToBackstackAndGoTo(
+                        screen = NavItem.QrScan,
+                        requestedDocs = RequestedDocsHolder(items = emptyList())
+                    ),
+                    awaitItem()
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `OnMenuClick emits navigation to the menu screen`() = runTest(testDispatcher) {
+        val viewModel = HomeViewModel(homeInteractor())
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnMenuClick)
+
+            assertEquals(Effect.Navigation.PushScreen(NavItem.Menu), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `OnTapToCreateRequest emits navigation to the documents-to-request screen`() =
+        runTest(testDispatcher) {
+            val viewModel = HomeViewModel(homeInteractor())
+
+            viewModel.effect.test {
+                viewModel.setEvent(Event.OnTapToCreateRequest)
+
+                assertEquals(
+                    Effect.Navigation.SaveDocsToBackstackAndGoTo(
+                        screen = NavItem.DocToRequest,
+                        requestedDocs = RequestedDocsHolder(items = emptyList())
+                    ),
+                    awaitItem()
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    //endregion
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/menu/MenuViewModelTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/menu/MenuViewModelTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.presentation.ui.menu
+
+import app.cash.turbine.test
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import eu.europa.ec.euidi.verifier.domain.interactor.MenuInteractor
+import eu.europa.ec.euidi.verifier.presentation.MviViewModelTest
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemDataUi
+import eu.europa.ec.euidi.verifier.presentation.component.ListItemMainContentDataUi
+import eu.europa.ec.euidi.verifier.presentation.navigation.NavItem
+import eu.europa.ec.euidi.verifier.presentation.ui.menu.MenuViewModelContract.Effect
+import eu.europa.ec.euidi.verifier.presentation.ui.menu.MenuViewModelContract.Event
+import eu.europa.ec.euidi.verifier.presentation.ui.menu.model.MenuItemUi
+import eu.europa.ec.euidi.verifier.presentation.ui.menu.model.MenuTypeUi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class MenuViewModelTest : MviViewModelTest() {
+
+    private val menuItems = listOf(
+        MenuItemUi(
+            type = MenuTypeUi.HOME,
+            data = ListItemDataUi(
+                itemId = "home",
+                mainContentData = ListItemMainContentDataUi.Text("Home")
+            )
+        )
+    )
+
+    private fun menuInteractor(): MenuInteractor = mock {
+        everySuspend { getScreenTitle() } returns "Menu"
+        everySuspend { getMenuItemsUi() } returns menuItems
+        every { getAppVersion() } returns "1.0.0"
+    }
+
+    @Test
+    fun `Init loads title, menu items and app version`() = runTest(testDispatcher) {
+        val viewModel = MenuViewModel(menuInteractor())
+
+        viewModel.setEvent(Event.Init)
+
+        val state = viewModel.uiState.value
+        assertEquals("Menu", state.screenTitle)
+        assertEquals(menuItems, state.menuItems)
+        assertEquals("1.0.0", state.appVersion)
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `OnBackClicked emits Pop`() = runTest(testDispatcher) {
+        val viewModel = MenuViewModel(menuInteractor())
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnBackClicked)
+            assertEquals(Effect.Navigation.Pop, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `MenuItemClicked HOME pops to the home screen`() = runTest(testDispatcher) {
+        val viewModel = MenuViewModel(menuInteractor())
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.MenuItemClicked(MenuTypeUi.HOME))
+            assertEquals(
+                Effect.Navigation.PopTo(route = NavItem.Home, inclusive = false),
+                awaitItem()
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `MenuItemClicked SETTINGS pushes the settings screen`() = runTest(testDispatcher) {
+        val viewModel = MenuViewModel(menuInteractor())
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.MenuItemClicked(MenuTypeUi.SETTINGS))
+            assertEquals(
+                Effect.Navigation.PushScreen(
+                    route = NavItem.Settings,
+                    popUpTo = NavItem.Menu,
+                    inclusive = false
+                ),
+                awaitItem()
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/qr_scan/QrScanViewModelTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/qr_scan/QrScanViewModelTest.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.presentation.ui.qr_scan
+
+import app.cash.turbine.test
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import eu.europa.ec.euidi.verifier.domain.interactor.QrScanInteractor
+import eu.europa.ec.euidi.verifier.presentation.MviViewModelTest
+import eu.europa.ec.euidi.verifier.presentation.model.RequestedDocsHolder
+import eu.europa.ec.euidi.verifier.presentation.ui.qr_scan.QrScanViewModelContract.Effect
+import eu.europa.ec.euidi.verifier.presentation.ui.qr_scan.QrScanViewModelContract.Event
+import eu.europa.ec.euidi.verifier.testutil.TestData
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class QrScanViewModelTest : MviViewModelTest() {
+
+    private val docs = listOf(TestData.pidFullRequestedDocument)
+
+    private fun qrScanInteractor(qrValid: Boolean = true): QrScanInteractor = mock {
+        everySuspend { getScreenTitle() } returns "Scan QR"
+        everySuspend { getInvalidQrCodeMessage() } returns "Invalid QR"
+        everySuspend { getMissingDocumentsMessage() } returns "Missing documents"
+        every { qrCodeIsValid(any()) } returns qrValid
+    }
+
+    //region Init
+
+    @Test
+    fun `Init with docs sets title and requested docs`() = runTest(testDispatcher) {
+        val viewModel = QrScanViewModel(qrScanInteractor())
+
+        viewModel.setEvent(Event.Init(docs = docs))
+
+        val state = viewModel.uiState.value
+        assertEquals("Scan QR", state.screenTitle)
+        assertEquals(docs, state.requestedDocs)
+        assertFalse(state.isLoading)
+        assertFalse(state.finishedScanning)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `Init with no docs finishes scanning and shows the missing-documents error`() =
+        runTest(testDispatcher) {
+            val viewModel = QrScanViewModel(qrScanInteractor())
+
+            viewModel.setEvent(Event.Init(docs = null))
+
+            val state = viewModel.uiState.value
+            assertTrue(state.finishedScanning)
+            assertEquals("Missing documents", state.error?.errorSubTitle)
+        }
+
+    //endregion
+
+    //region scanning
+
+    @Test
+    fun `OnQrScanned with a valid code navigates to the transfer status screen`() =
+        runTest(testDispatcher) {
+            val viewModel = QrScanViewModel(qrScanInteractor(qrValid = true))
+            viewModel.setEvent(Event.Init(docs = docs))
+
+            viewModel.effect.test {
+                viewModel.setEvent(Event.OnQrScanned("mdoc:abc"))
+                assertEquals(
+                    Effect.Navigation.NavigateToTransferStatusScreen(
+                        requestedDocs = RequestedDocsHolder(items = docs),
+                        qrCode = "mdoc:abc"
+                    ),
+                    awaitItem()
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertTrue(viewModel.uiState.value.finishedScanning)
+        }
+
+    @Test
+    fun `OnQrScanned with an invalid code shows the invalid-code error`() =
+        runTest(testDispatcher) {
+            val viewModel = QrScanViewModel(qrScanInteractor(qrValid = false))
+            viewModel.setEvent(Event.Init(docs = docs))
+
+            viewModel.setEvent(Event.OnQrScanned("bad"))
+
+            val state = viewModel.uiState.value
+            assertEquals("Invalid QR", state.error?.errorSubTitle)
+            assertTrue(state.finishedScanning)
+        }
+
+    @Test
+    fun `OnQrScanned is ignored once scanning has finished`() = runTest(testDispatcher) {
+        val viewModel = QrScanViewModel(qrScanInteractor())
+        // Init with no docs sets finishedScanning = true and the missing-documents error.
+        viewModel.setEvent(Event.Init(docs = null))
+
+        viewModel.setEvent(Event.OnQrScanned("mdoc:abc"))
+
+        // Unchanged: still the missing-documents error, no navigation.
+        assertEquals("Missing documents", viewModel.uiState.value.error?.errorSubTitle)
+    }
+
+    //endregion
+
+    //region errors
+
+    @Test
+    fun `DismissError clears the error`() = runTest(testDispatcher) {
+        val viewModel = QrScanViewModel(qrScanInteractor())
+        viewModel.setEvent(Event.Init(docs = null)) // sets an error
+
+        viewModel.setEvent(Event.DismissError)
+
+        assertNull(viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `OnQrScanFailed sets an error whose cancel action pops and clears it`() =
+        runTest(testDispatcher) {
+            val viewModel = QrScanViewModel(qrScanInteractor())
+
+            viewModel.effect.test {
+                viewModel.setEvent(Event.OnQrScanFailed("boom"))
+
+                val error = viewModel.uiState.value.error
+                assertEquals("boom", error?.errorSubTitle)
+                assertTrue(viewModel.uiState.value.finishedScanning)
+
+                error?.onCancel?.invoke()
+
+                assertNull(viewModel.uiState.value.error)
+                assertEquals(Effect.Navigation.Pop, awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `OnQrScanFailed is ignored when an error is already shown`() = runTest(testDispatcher) {
+        val viewModel = QrScanViewModel(qrScanInteractor())
+
+        viewModel.setEvent(Event.OnQrScanFailed("first"))
+        viewModel.setEvent(Event.OnQrScanFailed("second"))
+
+        assertEquals("first", viewModel.uiState.value.error?.errorSubTitle)
+    }
+
+    @Test
+    fun `OnBackClicked emits Pop`() = runTest(testDispatcher) {
+        val viewModel = QrScanViewModel(qrScanInteractor())
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnBackClicked)
+            assertEquals(Effect.Navigation.Pop, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    //endregion
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/settings/SettingsViewModelTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/settings/SettingsViewModelTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.presentation.ui.settings
+
+import app.cash.turbine.test
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import eu.europa.ec.euidi.verifier.core.controller.PrefKey
+import eu.europa.ec.euidi.verifier.domain.interactor.SettingsInteractor
+import eu.europa.ec.euidi.verifier.presentation.MviViewModelTest
+import eu.europa.ec.euidi.verifier.presentation.navigation.NavItem
+import eu.europa.ec.euidi.verifier.presentation.ui.settings.SettingsViewModelContract.Effect
+import eu.europa.ec.euidi.verifier.presentation.ui.settings.SettingsViewModelContract.Event
+import eu.europa.ec.euidi.verifier.presentation.ui.settings.model.SettingsItemUi
+import eu.europa.ec.euidi.verifier.presentation.ui.settings.model.SettingsTypeUi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SettingsViewModelTest : MviViewModelTest() {
+
+    private val settingsItems = listOf<SettingsItemUi>(
+        SettingsItemUi.CategoryHeader(title = "General")
+    )
+    private val refreshedItems = listOf<SettingsItemUi>(
+        SettingsItemUi.CategoryHeader(title = "General"),
+        SettingsItemUi.CategoryHeader(title = "Updated")
+    )
+
+    private fun settingsInteractor(
+        items: List<SettingsItemUi> = settingsItems
+    ): SettingsInteractor = mock(MockMode.autoUnit) {
+        everySuspend { getScreenTitle() } returns "Settings"
+        everySuspend { getSettingsItemsUi() } returns items
+    }
+
+    @Test
+    fun `Init loads title and settings items`() = runTest(testDispatcher) {
+        val viewModel = SettingsViewModel(settingsInteractor())
+
+        viewModel.setEvent(Event.Init)
+
+        val state = viewModel.uiState.value
+        assertEquals("Settings", state.screenTitle)
+        assertEquals(settingsItems, state.settingsItems)
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `OnBackClicked emits Pop`() = runTest(testDispatcher) {
+        val viewModel = SettingsViewModel(settingsInteractor())
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnBackClicked)
+            assertEquals(Effect.Navigation.Pop, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `OnStickyButtonClicked pops to the home screen`() = runTest(testDispatcher) {
+        val viewModel = SettingsViewModel(settingsInteractor())
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnStickyButtonClicked)
+            assertEquals(
+                Effect.Navigation.PopTo(route = NavItem.Home, inclusive = false),
+                awaitItem()
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `SettingsItemClicked toggles the preference and refreshes the items`() =
+        runTest(testDispatcher) {
+            val interactor = settingsInteractor(items = refreshedItems)
+            val viewModel = SettingsViewModel(interactor)
+
+            viewModel.setEvent(Event.SettingsItemClicked(SettingsTypeUi.RetainData))
+
+            verifySuspend(exactly(1)) { interactor.togglePrefBoolean(PrefKey.RETAIN_DATA) }
+            assertEquals(refreshedItems, viewModel.uiState.value.settingsItems)
+        }
+
+    @Test
+    fun `PushScreen navigation effect exposes its route, popUpTo and inclusive flag`() {
+        // PushScreen is part of the navigation contract consumed by SettingsScreen's exhaustive
+        // when, even though the ViewModel itself only emits Pop / PopTo.
+        val effect = Effect.Navigation.PushScreen(
+            route = NavItem.Settings,
+            popUpTo = NavItem.Menu,
+            inclusive = true,
+        )
+        val same = Effect.Navigation.PushScreen(
+            route = NavItem.Settings,
+            popUpTo = NavItem.Menu,
+            inclusive = true,
+        )
+
+        assertEquals(NavItem.Settings, effect.route)
+        assertEquals(NavItem.Menu, effect.popUpTo)
+        assertTrue(effect.inclusive)
+        assertEquals(same, effect)
+    }
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/show_document/ShowDocumentsViewModelTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/show_document/ShowDocumentsViewModelTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.presentation.ui.show_document
+
+import app.cash.turbine.test
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import eu.europa.ec.euidi.verifier.domain.interactor.ShowDocumentsInteractor
+import eu.europa.ec.euidi.verifier.presentation.MviViewModelTest
+import eu.europa.ec.euidi.verifier.presentation.navigation.NavItem
+import eu.europa.ec.euidi.verifier.presentation.ui.show_document.ShowDocumentViewModelContract.Effect
+import eu.europa.ec.euidi.verifier.presentation.ui.show_document.ShowDocumentViewModelContract.Event
+import eu.europa.ec.euidi.verifier.presentation.ui.show_document.model.DocumentUi
+import eu.europa.ec.euidi.verifier.testutil.TestData
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class ShowDocumentsViewModelTest : MviViewModelTest() {
+
+    private val receivedDocs = listOf(TestData.pidReceivedDocument)
+
+    private val documentUi = DocumentUi(
+        id = "doc-1",
+        docType = "pid",
+        uiClaims = emptyList(),
+        validityInfo = emptyList()
+    )
+
+    private fun showDocumentsInteractor(): ShowDocumentsInteractor = mock {
+        everySuspend { getScreenTitle() } returns "Documents"
+        everySuspend { transformToUiItems(receivedDocs) } returns listOf(documentUi)
+    }
+
+    @Test
+    fun `Init loads title and transformed items`() = runTest(testDispatcher) {
+        val viewModel = ShowDocumentsViewModel(showDocumentsInteractor())
+
+        viewModel.setEvent(Event.Init(items = receivedDocs))
+
+        val state = viewModel.uiState.value
+        assertEquals("Documents", state.screenTitle)
+        assertEquals(listOf(documentUi), state.items)
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `OnDoneClick pops to the home screen`() = runTest(testDispatcher) {
+        val viewModel = ShowDocumentsViewModel(showDocumentsInteractor())
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnDoneClick)
+            assertEquals(
+                Effect.Navigation.PopTo(route = NavItem.Home, inclusive = false),
+                awaitItem()
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `OnBackClick pops to the home screen`() = runTest(testDispatcher) {
+        val viewModel = ShowDocumentsViewModel(showDocumentsInteractor())
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnBackClick)
+            assertEquals(
+                Effect.Navigation.PopTo(route = NavItem.Home, inclusive = false),
+                awaitItem()
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/show_document/model/DocumentValidityMappersTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/show_document/model/DocumentValidityMappersTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+@file:OptIn(ExperimentalTime::class)
+
+package eu.europa.ec.euidi.verifier.presentation.ui.show_document.model
+
+import dev.mokkery.answering.calls
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
+import eu.europa.ec.euidi.verifier.domain.model.DocumentValidityDomain
+import eu.europa.ec.euidi.verifier.testutil.sequentialUuidProvider
+import org.jetbrains.compose.resources.StringResource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+class DocumentValidityMappersTest {
+
+    private fun resourceProvider(): ResourceProvider = mock {
+        every { getSharedString(any()) } calls { (_: StringResource) -> "label" }
+    }
+
+    //region toUi
+
+    @Test
+    fun `toUi maps the booleans and formats the instants`() {
+        val instant = Instant.parse("2025-12-10T12:00:00Z")
+        val domain = DocumentValidityDomain(
+            isDeviceSignatureValid = true,
+            isIssuerSignatureValid = false,
+            isDataIntegrityIntact = true,
+            signed = instant,
+            validFrom = instant,
+            validUntil = instant,
+        )
+
+        val ui = domain.toUi()
+
+        assertEquals(true, ui.isDeviceSignatureValid)
+        assertEquals(false, ui.isIssuerSignatureValid)
+        assertEquals(true, ui.isDataIntegrityIntact)
+        // Formatted as "dd MMM yyyy" (in the system time zone).
+        val dateRegex = Regex("""\d{2} \w{3} \d{4}""")
+        assertTrue(ui.signed?.matches(dateRegex) == true, "Unexpected date format: ${ui.signed}")
+        assertEquals(ui.signed, ui.validFrom)
+        assertEquals(ui.signed, ui.validUntil)
+    }
+
+    @Test
+    fun `toUi defaults null booleans to false and keeps null instants null`() {
+        val domain = DocumentValidityDomain(
+            isDeviceSignatureValid = null,
+            isIssuerSignatureValid = null,
+            isDataIntegrityIntact = null,
+            signed = null,
+            validFrom = null,
+            validUntil = null,
+        )
+
+        val ui = domain.toUi()
+
+        assertEquals(false, ui.isDeviceSignatureValid)
+        assertEquals(false, ui.isIssuerSignatureValid)
+        assertEquals(false, ui.isDataIntegrityIntact)
+        assertNull(ui.signed)
+        assertNull(ui.validFrom)
+        assertNull(ui.validUntil)
+    }
+
+    //endregion
+
+    //region toListItems
+
+    @Test
+    fun `toListItems builds three boolean items plus the non-null string items`() {
+        val ui = DocumentValidityUi(
+            isDeviceSignatureValid = true,
+            isIssuerSignatureValid = false,
+            isDataIntegrityIntact = true,
+            signed = "10 Dec 2025",
+            validFrom = null,         // omitted
+            validUntil = "31 Dec 2025",
+        )
+
+        val items = ui.toListItems(
+            resourceProvider = resourceProvider(),
+            uuidProvider = sequentialUuidProvider(),
+        )
+
+        // 3 boolean items + signed + validUntil (validFrom is null and dropped) = 5
+        assertEquals(5, items.size)
+    }
+
+    @Test
+    fun `toListItems drops all optional string items when they are null`() {
+        val ui = DocumentValidityUi(
+            isDeviceSignatureValid = false,
+            isIssuerSignatureValid = false,
+            isDataIntegrityIntact = false,
+            signed = null,
+            validFrom = null,
+            validUntil = null,
+        )
+
+        val items = ui.toListItems(
+            resourceProvider = resourceProvider(),
+            uuidProvider = sequentialUuidProvider(),
+        )
+
+        assertEquals(3, items.size)
+    }
+
+    //endregion
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/transfer_status/TransferStatusViewModelTest.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/transfer_status/TransferStatusViewModelTest.kt
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.presentation.ui.transfer_status
+
+import app.cash.turbine.test
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import eu.europa.ec.euidi.verifier.core.controller.TransferStatus
+import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
+import eu.europa.ec.euidi.verifier.domain.interactor.TransferStatusInteractor
+import eu.europa.ec.euidi.verifier.domain.model.ReceivedDocumentsDomain
+import eu.europa.ec.euidi.verifier.presentation.MviViewModelTest
+import eu.europa.ec.euidi.verifier.presentation.ui.transfer_status.TransferStatusViewModelContract.Effect
+import eu.europa.ec.euidi.verifier.presentation.ui.transfer_status.TransferStatusViewModelContract.Event
+import eu.europa.ec.euidi.verifier.testutil.TestData
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TransferStatusViewModelTest : MviViewModelTest() {
+
+    private val qrCode = "mdoc:test"
+    private val docs = listOf(TestData.pidFullRequestedDocument)
+
+    private fun transferInteractor(
+        statusFlow: Flow<TransferStatus> = flowOf()
+    ): TransferStatusInteractor = mock(MockMode.autoUnit) {
+        everySuspend { getRequestData(any()) } returns "Requesting: Full PID"
+        everySuspend { getConnectionStatus(any()) } returns statusFlow
+    }
+
+    private fun resourceProvider(): ResourceProvider = mock {
+        every { getSharedString(any(), *any()) } returns "status"
+    }
+
+    private fun viewModel(
+        interactor: TransferStatusInteractor = transferInteractor(),
+        resourceProvider: ResourceProvider = resourceProvider(),
+    ) = TransferStatusViewModel(interactor, resourceProvider, qrCode)
+
+    //region Init
+
+    @Test
+    fun `Init loads the requested document types`() = runTest(testDispatcher) {
+        val viewModel = viewModel()
+
+        viewModel.setEvent(Event.Init(docs = docs))
+
+        val state = viewModel.uiState.value
+        assertEquals("Requesting: Full PID", state.requestedDocTypes)
+        assertEquals(docs, state.requestedDocs)
+        assertFalse(state.isLoading)
+    }
+
+    //endregion
+
+    //region permissions
+
+    @Test
+    fun `RequestPermissions marks progress and emits the request effect`() =
+        runTest(testDispatcher) {
+            val viewModel = viewModel()
+
+            viewModel.effect.test {
+                viewModel.setEvent(Event.RequestPermissions)
+                assertEquals(Effect.RequestPermissions, awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertTrue(viewModel.uiState.value.permissionsRequestInProgress)
+        }
+
+    @Test
+    fun `RequestPermissions is ignored while a request is already in progress`() =
+        runTest(testDispatcher) {
+            val viewModel = viewModel()
+
+            viewModel.effect.test {
+                viewModel.setEvent(Event.RequestPermissions)
+                assertEquals(Effect.RequestPermissions, awaitItem())
+
+                viewModel.setEvent(Event.RequestPermissions)
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `PermissionReceived granted before engagement emits PermissionsGranted`() =
+        runTest(testDispatcher) {
+            val viewModel = viewModel()
+
+            viewModel.effect.test {
+                viewModel.setEvent(Event.PermissionReceived(denied = false))
+                assertEquals(Effect.PermissionsGranted, awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+            val state = viewModel.uiState.value
+            assertEquals(true, state.hasPermissions)
+            assertFalse(state.permissionsRequestInProgress)
+        }
+
+    @Test
+    fun `PermissionReceived denied during engagement emits PermissionsRevoked`() =
+        runTest(testDispatcher) {
+            val viewModel = viewModel(interactor = transferInteractor(statusFlow = flowOf()))
+            viewModel.setEvent(Event.Init(docs = docs))
+            viewModel.setEvent(Event.StartProximity) // engagementStarted = true
+
+            viewModel.effect.test {
+                viewModel.setEvent(Event.PermissionReceived(denied = true))
+                assertEquals(Effect.PermissionsRevoked, awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertEquals(false, viewModel.uiState.value.hasPermissions)
+        }
+
+    @Test
+    fun `PermissionReceived denied before engagement emits no effect`() =
+        runTest(testDispatcher) {
+            val viewModel = viewModel()
+
+            viewModel.effect.test {
+                viewModel.setEvent(Event.PermissionReceived(denied = true))
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertEquals(false, viewModel.uiState.value.hasPermissions)
+        }
+
+    @Test
+    fun `PermissionReceived granted during engagement emits no effect`() =
+        runTest(testDispatcher) {
+            val viewModel = viewModel(interactor = transferInteractor(statusFlow = flowOf()))
+            viewModel.setEvent(Event.Init(docs = docs))
+            viewModel.setEvent(Event.StartProximity) // engagementStarted = true
+
+            viewModel.effect.test {
+                viewModel.setEvent(Event.PermissionReceived(denied = false))
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertEquals(true, viewModel.uiState.value.hasPermissions)
+        }
+
+    @Test
+    fun `OpenAppSettings emits the open-settings effect`() = runTest(testDispatcher) {
+        val viewModel = viewModel()
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OpenAppSettings)
+            assertEquals(Effect.OpenAppSettings, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    //endregion
+
+    //region proximity / connection status
+
+    @Test
+    fun `StartProximity prepares the connection, starts engagement and maps non-terminal statuses`() =
+        runTest(testDispatcher) {
+            val interactor = transferInteractor(
+                statusFlow = flowOf(
+                    TransferStatus.Connected,
+                    TransferStatus.Connecting,
+                    TransferStatus.DeviceEngagementCompleted,
+                    TransferStatus.RequestSent,
+                )
+            )
+            val viewModel = viewModel(interactor = interactor)
+            viewModel.setEvent(Event.Init(docs = docs))
+
+            viewModel.setEvent(Event.StartProximity)
+
+            assertTrue(viewModel.uiState.value.engagementStarted)
+            assertEquals("status", viewModel.uiState.value.connectionStatus)
+            verifySuspend(exactly(1)) { interactor.prepareConnection() }
+            verify(exactly(1)) { interactor.startEngagement(qrCode) }
+        }
+
+    @Test
+    fun `An Error status navigates back`() = runTest(testDispatcher) {
+        val interactor = transferInteractor(statusFlow = flowOf(TransferStatus.Error("boom")))
+        val viewModel = viewModel(interactor = interactor)
+        viewModel.setEvent(Event.Init(docs = docs))
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.StartProximity)
+            assertEquals(Effect.Navigation.GoBack, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `A Disconnected status navigates back`() = runTest(testDispatcher) {
+        val interactor = transferInteractor(statusFlow = flowOf(TransferStatus.Disconnected))
+        val viewModel = viewModel(interactor = interactor)
+        viewModel.setEvent(Event.Init(docs = docs))
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.StartProximity)
+            assertEquals(Effect.Navigation.GoBack, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `An OnResponseReceived status navigates to the show-documents screen`() =
+        runTest(testDispatcher) {
+            val receivedUi = listOf(TestData.pidReceivedDocument)
+            val interactor = mock<TransferStatusInteractor>(MockMode.autoUnit) {
+                everySuspend { getRequestData(any()) } returns "Requesting: Full PID"
+                everySuspend {
+                    getConnectionStatus(any())
+                } returns flowOf(
+                    TransferStatus.OnResponseReceived(ReceivedDocumentsDomain(documents = emptyList()))
+                )
+                everySuspend { transformToReceivedDocumentsUi(any(), any()) } returns receivedUi
+            }
+            val viewModel = viewModel(interactor = interactor)
+            viewModel.setEvent(Event.Init(docs = docs))
+
+            viewModel.effect.test {
+                viewModel.setEvent(Event.StartProximity)
+                assertEquals(
+                    Effect.Navigation.NavigateToShowDocumentsScreen(receivedDocuments = receivedUi),
+                    awaitItem()
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `StopProximity stops the connection and resets engagement state`() =
+        runTest(testDispatcher) {
+            val interactor = transferInteractor()
+            val viewModel = viewModel(interactor = interactor)
+
+            viewModel.setEvent(Event.StopProximity)
+
+            val state = viewModel.uiState.value
+            assertFalse(state.engagementStarted)
+            assertFalse(state.isLoading)
+            verifySuspend(exactly(1)) { interactor.stopConnection() }
+        }
+
+    //endregion
+
+    //region back / cancel
+
+    @Test
+    fun `OnCancelClick stops the connection and navigates back`() = runTest(testDispatcher) {
+        val interactor = transferInteractor()
+        val viewModel = viewModel(interactor = interactor)
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnCancelClick)
+            assertEquals(Effect.Navigation.GoBack, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        verifySuspend(exactly(1)) { interactor.stopConnection() }
+    }
+
+    @Test
+    fun `OnBackClick navigates back`() = runTest(testDispatcher) {
+        val viewModel = viewModel()
+
+        viewModel.effect.test {
+            viewModel.setEvent(Event.OnBackClick)
+            assertEquals(Effect.Navigation.GoBack, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    //endregion
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/testutil/TestData.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/testutil/TestData.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.testutil
+
+import eu.europa.ec.euidi.verifier.domain.config.model.AttestationType
+import eu.europa.ec.euidi.verifier.domain.config.model.ClaimItem
+import eu.europa.ec.euidi.verifier.domain.config.model.DocumentMode
+import eu.europa.ec.euidi.verifier.domain.model.SupportedDocumentUi
+import eu.europa.ec.euidi.verifier.presentation.model.ReceivedDocumentUi
+import eu.europa.ec.euidi.verifier.presentation.model.RequestedDocumentUi
+import eu.europa.ec.euidi.verifier.presentation.ui.show_document.model.DocumentValidityUi
+import eu.europa.ec.euidi.verifier.testutil.TestData.ageClaim
+import eu.europa.ec.euidi.verifier.testutil.TestData.familyNameClaim
+
+/**
+ * Reusable, immutable test fixtures shared across the common tests.
+ *
+ * Only values that are duplicated across multiple test files live here. Test-specific variations
+ * (e.g. documents with particular claim subsets) are intentionally kept inline in their tests so
+ * the assertions stay self-explanatory.
+ *
+ * Note: these are immutable data-class instances and are safe to share. Mokkery mock instances are
+ * NOT shared here because they record interactions for verification — share mock *factories*
+ * (see [eu.europa.ec.euidi.verifier.testutil.sequentialUuidProvider]) instead.
+ */
+object TestData {
+
+    // region Claims
+    val familyNameClaim = ClaimItem(label = "family_name")
+    val givenNameClaim = ClaimItem(label = "given_name")
+    val ageClaim = ClaimItem(label = "age")
+
+    /** The PID claim subset ([familyNameClaim] + [ageClaim]) used by several document tests. */
+    val pidClaims = listOf(familyNameClaim, ageClaim)
+    // endregion
+
+    // region Requested documents
+    val pidFullRequestedDocument = RequestedDocumentUi(
+        id = "PID_DOC",
+        documentType = AttestationType.Pid,
+        mode = DocumentMode.FULL,
+    )
+
+    val pidCustomRequestedDocument = RequestedDocumentUi(
+        id = "PID_DOC",
+        documentType = AttestationType.Pid,
+        mode = DocumentMode.CUSTOM,
+    )
+
+    val mdlFullRequestedDocument = RequestedDocumentUi(
+        id = "MDL_DOC",
+        documentType = AttestationType.Mdl,
+        mode = DocumentMode.FULL,
+    )
+
+    val mdlCustomRequestedDocument = RequestedDocumentUi(
+        id = "MDL_DOC",
+        documentType = AttestationType.Mdl,
+        mode = DocumentMode.CUSTOM,
+    )
+    // endregion
+
+    // region Validity
+    val validDocumentValidityUi = DocumentValidityUi(
+        isDeviceSignatureValid = true,
+        isIssuerSignatureValid = true,
+        isDataIntegrityIntact = true,
+        signed = null,
+        validFrom = null,
+        validUntil = null,
+    )
+    // endregion
+
+    // region Supported documents
+    val pidSupportedDocument = SupportedDocumentUi(
+        id = "PID",
+        documentType = AttestationType.Pid,
+        modes = listOf(DocumentMode.FULL),
+    )
+
+    val mdlCustomSupportedDocument = SupportedDocumentUi(
+        id = "MDL",
+        documentType = AttestationType.Mdl,
+        modes = listOf(DocumentMode.CUSTOM),
+    )
+
+    /** The PID (full) + MDL (custom) pair used by the search tests. */
+    val searchableSupportedDocuments = listOf(pidSupportedDocument, mdlCustomSupportedDocument)
+    // endregion
+
+    // region Received documents
+    val pidReceivedDocument = ReceivedDocumentUi(
+        id = "doc-1",
+        documentType = AttestationType.Pid,
+        documentValidity = validDocumentValidityUi,
+    )
+    // endregion
+}

--- a/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/testutil/TestMocks.kt
+++ b/verifierApp/src/commonTest/kotlin/eu/europa/ec/euidi/verifier/testutil/TestMocks.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.euidi.verifier.testutil
+
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import eu.europa.ec.euidi.verifier.core.provider.ResourceProvider
+import eu.europa.ec.euidi.verifier.core.provider.UuidProvider
+import eudiverifier.verifierapp.generated.resources.Res
+import eudiverifier.verifierapp.generated.resources.document_type_employee_id
+import eudiverifier.verifierapp.generated.resources.document_type_mdl
+import eudiverifier.verifierapp.generated.resources.document_type_pid
+
+/**
+ * Shared Mokkery mock *factories* for the common tests.
+ *
+ * These are functions (not shared instances) on purpose: every call returns a fresh mock so that
+ * recorded interactions never leak between tests.
+ */
+
+/**
+ * A [UuidProvider] mock that returns deterministic, incrementing ids: "uuid-0", "uuid-1", ...
+ * Each invocation of this factory starts a fresh counter.
+ */
+fun sequentialUuidProvider(): UuidProvider {
+    var counter = 0
+    return mock {
+        every { provideUuid() } calls { "uuid-${counter++}" }
+    }
+}
+
+/**
+ * A [ResourceProvider] mock that maps the document-type display-name resources to short labels
+ * ("PID", "MDL", "Employee ID"). Tests that need additional strings can stub them on the returned
+ * mock, e.g. `documentTypeResourceProvider().apply { every { getSharedString(...) } returns ... }`.
+ */
+fun documentTypeResourceProvider(): ResourceProvider {
+    val resourceProvider = mock<ResourceProvider>()
+    every { resourceProvider.getSharedString(Res.string.document_type_pid) } returns "PID"
+    every { resourceProvider.getSharedString(Res.string.document_type_mdl) } returns "MDL"
+    every {
+        resourceProvider.getSharedString(Res.string.document_type_employee_id)
+    } returns "Employee ID"
+    return resourceProvider
+}


### PR DESCRIPTION
- Add `turbine` dependency for testing Coroutine Flows.
- Implement comprehensive unit tests for all ViewModels, including `HomeViewModel`, `QrScanViewModel`, `TransferStatusViewModel`, and `SettingsViewModel`.
- Add unit tests for core extensions and utility classes (`Base64Extensions`, `FlowExtensions`, `SafeLet`).
- Introduce centralized `TestData` and `TestMocks` in a new `testutil` package to share immutable fixtures and Mokkery factories across tests.
- Refactor existing interactor tests to use the new shared test utilities, reducing boilerplate.
- Improve initialization and button formatting logic in `HomeViewModel`.
- Expand Kover coverage filters to exclude generated code, dependency injection modules, and UI-specific components.
- Refactor `UiTransformer` to simplify claim translation lookups.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [x] Added Tests ()

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
